### PR TITLE
feat: add ARM build support for darwin and improve installer script

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,6 +16,13 @@ builds:
     goos: [linux]
     goarch: [amd64]
 
+  - id: darwin
+    main: ./cmd/minisky
+    binary: minisky
+    env: [CGO_ENABLED=1]
+    goos: [darwin]
+    goarch: [arm64]
+
   - id: windows
     main: ./cmd/minisky
     binary: minisky

--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,8 @@ esac
 echo "🛰️  Installing MiniSky for $OS/$ARCH..."
 
 # 2. Get latest version from GitHub
-VERSION=$(curl -s https://api.github.com/repos/$REPO/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+RELEASE_JSON=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest")
+VERSION=$(printf '%s' "$RELEASE_JSON" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
 
 if [ -z "$VERSION" ]; then
     echo "❌ Error: Could not detect latest version."
@@ -36,16 +37,24 @@ echo "📦 Found version $VERSION"
 
 # 3. Download and Install
 EXT="tar.gz"
-BIN_OUT="minisky"
+BIN_OUT="$BINARY_NAME"
 if [ "$OS" = "windows" ]; then 
     EXT="zip"
-    BIN_OUT="minisky.exe"
+    BIN_OUT="${BINARY_NAME}.exe"
 fi
 
 DOWNLOAD_URL="https://github.com/$REPO/releases/download/$VERSION/minisky_${OS}_${ARCH}.${EXT}"
+ASSET_NAME="minisky_${OS}_${ARCH}.${EXT}"
+DOWNLOAD_URL=$(printf '%s' "$RELEASE_JSON" | grep -o '"browser_download_url": "[^"]*"' | sed -E 's/.*"([^"]+)"/\1/' | grep "/${ASSET_NAME}$" | head -n 1 || true)
+
+if [ -z "$DOWNLOAD_URL" ]; then
+    echo "❌ Error: Release $VERSION does not include ${ASSET_NAME}."
+    echo "This platform is not published in the latest release yet."
+    exit 1
+fi
 
 echo "📥 Downloading from $DOWNLOAD_URL..."
-curl -sSL -o "minisky.$EXT" "$DOWNLOAD_URL"
+curl -fsSL -o "minisky.$EXT" "$DOWNLOAD_URL"
 
 if [ "$EXT" = "tar.gz" ]; then
     tar -xzf "minisky.$EXT" minisky
@@ -58,12 +67,14 @@ if [ "$OS" = "windows" ]; then
     echo "✅ MiniSky binary ($BIN_OUT) is ready in the current directory."
     echo "To use it globally, add this folder to your Windows PATH."
 else
-    echo "🚀 Installing 'minisky' to /usr/local/bin..."
-    sudo mv ./minisky /usr/local/bin/minisky
-    sudo chmod +x /usr/local/bin/minisky
+    echo "🚀 Installing '$BIN_OUT' to /usr/local/bin..."
+    sudo mv "./$BIN_OUT" "/usr/local/bin/$BIN_OUT"
+    sudo chmod +x "/usr/local/bin/$BIN_OUT"
 fi
 
-rm "minisky.$EXT"
+if [ -f "minisky.$EXT" ]; then
+    rm "minisky.$EXT"
+fi
 
 # 4. Final check
 echo ""

--- a/pkg/orchestrator/dialer_unix.go
+++ b/pkg/orchestrator/dialer_unix.go
@@ -17,6 +17,7 @@ func resolveDockerSocket() string {
 	}
 	// 2. Probe known locations in priority order
 	candidates := []string{
+		filepath.Join(os.Getenv("HOME"), ".docker", "run", "docker.sock"),     // Docker Desktop (current macOS)
 		filepath.Join(os.Getenv("HOME"), ".docker", "desktop", "docker.sock"), // Docker Desktop (Linux/Mac)
 		filepath.Join(os.Getenv("XDG_RUNTIME_DIR"), "docker.sock"),            // Rootless Docker
 		filepath.Join(os.Getenv("XDG_RUNTIME_DIR"), "podman", "podman.sock"),  // Podman


### PR DESCRIPTION
This fixes the installer behavior, but I think the real platform issue is in the release pipeline.

Right now [install.sh](install.sh#L45) expects a `minisky_darwin_arm64.tar.gz` asset for macOS Apple Silicon, but the current releases do not publish one. That causes macOS installs to fetch a missing URL and fail later during extraction.

This PR adds the `darwin/arm64` target in [.goreleaser.yaml](.goreleaser.yaml#L16), but for that to actually produce a usable release artifact, the release workflow also needs to run GoReleaser in an environment that can build CGO-enabled Darwin binaries. Since the Darwin target here uses `CGO_ENABLED=1`, I think the release job should run on a macOS runner, or use an equivalent release setup that can build macOS arm64 binaries correctly.

What I validated locally:
- `go run github.com/goreleaser/goreleaser/v2@latest check` passes with the Darwin target added
- the installer now fails clearly instead of downloading a 404 page into `tar`

What still needs maintainer-side validation:
- cut a release from the updated config
- confirm that GitHub Releases includes `minisky_darwin_arm64.tar.gz`
- confirm `curl -sSL https://minisky.bmics.com.ng/install.sh | bash` works on macOS arm64 against that release