### PR TITLE
feat: attach compute VMs to every VPC network their interfaces reference

### DIFF
--- a/pkg/orchestrator/manager.go
+++ b/pkg/orchestrator/manager.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -20,13 +21,68 @@ import (
 
 const networkName = "minisky-net"
 
+// DockerNetworkNameForVPC maps a VPC name to the Docker network that backs it:
+// "" or "default" is the shared bridge, everything else gets its own
+// "minisky-vpc-<name>" network. This is the single source of truth for the
+// mapping — every place that needs to go from VPC name to Docker network (or
+// back) should call this or VPCNameForDockerNetwork instead of re-deriving it.
+func DockerNetworkNameForVPC(vpcName string) string {
+	if vpcName == "" || vpcName == "default" {
+		return networkName
+	}
+	return "minisky-vpc-" + vpcName
+}
+
+// VPCNameForDockerNetwork is the inverse of DockerNetworkNameForVPC: given a
+// Docker network name, returns the VPC name it represents, or ("", false) if
+// the network isn't one minisky manages (e.g. Docker's own "bridge" network).
+func VPCNameForDockerNetwork(dockerNet string) (string, bool) {
+	if dockerNet == networkName {
+		return "default", true
+	}
+	if strings.HasPrefix(dockerNet, "minisky-vpc-") {
+		return strings.TrimPrefix(dockerNet, "minisky-vpc-"), true
+	}
+	return "", false
+}
+
+// MergeUniquePorts returns the ports allowed across every given VPC, deduped
+// while preserving first-seen order. portsFor returns the ingress-allow ports
+// for a single VPC (e.g. ServiceManager.allowedPortsForVPC or a shim's
+// getAllowedPortsForVPC), so both orchestrator and shim packages can share
+// this merge logic instead of reimplementing it.
+func MergeUniquePorts(vpcNames []string, portsFor func(string) []string) []string {
+	var merged []string
+	for _, vpc := range vpcNames {
+		merged = append(merged, portsFor(vpc)...)
+	}
+	return dedupStrings(merged)
+}
+
+// dedupStrings removes duplicate entries while preserving first-seen order.
+func dedupStrings(in []string) []string {
+	if len(in) == 0 {
+		return in
+	}
+	seen := make(map[string]bool, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
 // ServiceManager handles native REST-driven lifecycle events over the Docker Unix Socket.
 type ServiceManager struct {
 	mu           sync.RWMutex
 	dockerClient *http.Client
 	sockPath     string
-	portRegistry map[string][]PortMapping  // containerName → host ports
+	portRegistry map[string][]PortMapping   // containerName → host ports
 	fwRules      map[string][]FirewallEntry // vpcName → rules
+	vpcRegistry  map[string][]string        // containerName → vpcNames it was last provisioned with
 }
 
 // ContainerConfig describes one backend emulator container.
@@ -60,20 +116,34 @@ type FirewallEntry struct {
 func NewServiceManager() (*ServiceManager, error) {
 	sockPath := resolveDockerSocket()
 	// On Unix, ensure DOCKER_HOST is set if we found a socket
-	if !strings.HasPrefix(sockPath, "//./pipe/") && os.Getenv("DOCKER_HOST") == "" { 
-		os.Setenv("DOCKER_HOST", "unix://"+sockPath); 
+	if !strings.HasPrefix(sockPath, "//./pipe/") && os.Getenv("DOCKER_HOST") == "" {
+		os.Setenv("DOCKER_HOST", "unix://"+sockPath)
 	}
 	log.Printf("[ServiceManager] Docker socket resolved: %s", sockPath)
 	sm := &ServiceManager{
 		sockPath:     sockPath,
 		portRegistry: make(map[string][]PortMapping),
 		fwRules:      make(map[string][]FirewallEntry),
+		vpcRegistry:  make(map[string][]string),
 	}
 	transport := &http.Transport{
 		DialContext: sm.dialDocker,
 	}
 	sm.dockerClient = &http.Client{Transport: transport}
 	return sm, nil
+}
+
+// NewServiceManagerForTesting builds a ServiceManager backed by the given
+// http.RoundTripper instead of a real Docker socket, so other packages' tests
+// can exercise Docker-calling logic (e.g. compute's patchNetworkIPs) without a
+// Docker daemon.
+func NewServiceManagerForTesting(transport http.RoundTripper) *ServiceManager {
+	return &ServiceManager{
+		dockerClient: &http.Client{Transport: transport},
+		portRegistry: make(map[string][]PortMapping),
+		fwRules:      make(map[string][]FirewallEntry),
+		vpcRegistry:  make(map[string][]string),
+	}
 }
 
 // EnsureNetwork creates the isolated minisky-net bridge network if it doesn't exist.
@@ -201,6 +271,10 @@ func (sm *ServiceManager) StopAndRemoveContainer(name string) error {
 		return err
 	}
 	defer respRm.Body.Close()
+	if respRm.StatusCode >= 400 && respRm.StatusCode != http.StatusNotFound {
+		b, _ := io.ReadAll(respRm.Body)
+		return fmt.Errorf("remove container %q rejected %d: %s", name, respRm.StatusCode, b)
+	}
 	return nil
 }
 
@@ -459,9 +533,18 @@ func (sm *ServiceManager) ImageExistsPublic(image string) (bool, error) {
 }
 
 // ProvisionComputeVM actively boots a Data Plane Docker container mimicking a GCE VM.
-func (sm *ServiceManager) ProvisionComputeVM(containerName string, osImage string, vpcName string, ports []string, env []string, cmd []string) error {
-	log.Printf("[Orchestrator] Provisioning compute VM: %s (image: %s vpc: %s ports: %d env: %d cmd: %v)", containerName, osImage, vpcName, len(ports), len(env), cmd)
-	
+// It also creates the container on its primary network (vpcNames[0], or
+// "default" if empty). Docker's /containers/create only accepts one network at
+// creation time, so any additional entries in vpcNames are attached afterwards
+// via ConnectContainerToNetwork.
+func (sm *ServiceManager) ProvisionComputeVM(containerName string, osImage string, vpcNames []string, ports []string, env []string, cmd []string) error {
+	vpcNames = dedupStrings(vpcNames)
+	primaryVpc := "default"
+	if len(vpcNames) > 0 {
+		primaryVpc = vpcNames[0]
+	}
+	log.Printf("[Orchestrator] Provisioning compute VM: %s (image: %s vpcs: %v ports: %d env: %d cmd: %v)", containerName, osImage, vpcNames, len(ports), len(env), cmd)
+
 	exists, err := sm.ImageExistsPublic(osImage)
 	if err != nil {
 		log.Printf("[Orchestrator] Image check error for %s: %v", osImage, err)
@@ -474,10 +557,7 @@ func (sm *ServiceManager) ProvisionComputeVM(containerName string, osImage strin
 		log.Printf("[Orchestrator] Image '%s' already exists locally, skipping pull.", osImage)
 	}
 
-	netMode := networkName
-	if vpcName != "" && vpcName != "default" {
-		netMode = "minisky-vpc-" + vpcName
-	}
+	netMode := DockerNetworkNameForVPC(primaryVpc)
 
 	exposedPorts := make(map[string]interface{})
 	portBindings := make(map[string]interface{})
@@ -507,29 +587,63 @@ func (sm *ServiceManager) ProvisionComputeVM(containerName string, osImage strin
 	url := fmt.Sprintf("http://localhost/containers/create?name=%s", containerName)
 	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(data))
 	req.Header.Set("Content-Type", "application/json")
-	
+
 	resp, err := sm.dockerClient.Do(req)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-	
+
 	if resp.StatusCode >= 400 && resp.StatusCode != http.StatusConflict { // 409
 		b, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("vm creation rejected %d: %s", resp.StatusCode, b)
 	}
 
+	// From here on, GCE's instances.insert is atomic — a VM either comes up fully
+	// or doesn't get created at all — so any failure rolls the container back
+	// rather than leaving a half-provisioned container behind.
 	if err := sm.startContainer(containerName); err != nil {
-		return err
+		if rmErr := sm.StopAndRemoveContainer(containerName); rmErr != nil {
+			log.Printf("[Orchestrator] rollback of '%s' after start failure failed: %v", containerName, rmErr)
+		}
+		return fmt.Errorf("start container %q: %v", containerName, err)
 	}
-	
+
+	// Attach every network past the primary one now that the container exists.
+	// A failed attach here rolls the container back the same way, rather than
+	// leaving it half-attached. ConnectContainerToNetwork tolerates the container already being a
+	// member of the target network, so a retried/duplicate call for the same
+	// containerName+vpcNames (e.g. a retried insert, or a firewall-triggered recreate
+	// whose preceding delete didn't fully take effect) is idempotent and won't roll
+	// back an otherwise-healthy container.
+	var extraVPCs []string
+	if len(vpcNames) > 0 {
+		extraVPCs = vpcNames[1:]
+	}
+	for _, extra := range extraVPCs {
+		if err := sm.ConnectContainerToNetwork(containerName, extra); err != nil {
+			if rmErr := sm.StopAndRemoveContainer(containerName); rmErr != nil {
+				log.Printf("[Orchestrator] rollback of '%s' failed: %v", containerName, rmErr)
+			}
+			return fmt.Errorf("attach network %q: %v", extra, err)
+		}
+	}
+
+	finalVPCNames := vpcNames
+	if len(finalVPCNames) == 0 {
+		finalVPCNames = []string{"default"}
+	}
+	sm.mu.Lock()
+	sm.vpcRegistry[containerName] = finalVPCNames
+	sm.mu.Unlock()
+
 	return sm.updatePortRegistry(containerName)
 }
 
 // ProvisionCloudSQLVM starts a fully-interactive PostgreSQL or MySQL docker database data plane.
 func (sm *ServiceManager) ProvisionBuildStep(containerName string, image string, binds []string, env []string, cmd []string) error {
 	log.Printf("[Orchestrator] Provisioning build step: %s (image: %s binds: %v cmd: %v)", containerName, image, binds, cmd)
-	
+
 	exists, _ := sm.ImageExistsPublic(image)
 	if !exists {
 		sm.pullImageInternal(image)
@@ -555,13 +669,13 @@ func (sm *ServiceManager) ProvisionBuildStep(containerName string, image string,
 	url := fmt.Sprintf("http://localhost/containers/create?name=%s", containerName)
 	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(data))
 	req.Header.Set("Content-Type", "application/json")
-	
+
 	resp, err := sm.dockerClient.Do(req)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-	
+
 	if resp.StatusCode >= 400 && resp.StatusCode != http.StatusConflict {
 		b, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("build step creation rejected %d: %s", resp.StatusCode, b)
@@ -591,8 +705,8 @@ func (sm *ServiceManager) ProvisionCloudSQLVM(instanceName string, version strin
 		if image == "" {
 			image = reg.Sql.Postgres.DefaultImage
 		}
-		env = append(sm.standardEnv(), 
-			"POSTGRES_PASSWORD=" + rootPassword,
+		env = append(sm.standardEnv(),
+			"POSTGRES_PASSWORD="+rootPassword,
 			"PGDATA=/var/lib/postgresql/data",
 		)
 		expPort = "5432/tcp"
@@ -614,7 +728,7 @@ func (sm *ServiceManager) ProvisionCloudSQLVM(instanceName string, version strin
 		if image == "" {
 			image = reg.Sql.Mysql.DefaultImage
 		}
-		env = append(sm.standardEnv(), "MYSQL_ROOT_PASSWORD=" + rootPassword)
+		env = append(sm.standardEnv(), "MYSQL_ROOT_PASSWORD="+rootPassword)
 		expPort = "3306/tcp"
 	} else {
 		return "", fmt.Errorf("unsupported database version: %s", version)
@@ -722,7 +836,7 @@ func (sm *ServiceManager) DeleteCloudSQLVM(instanceName string) error {
 // DeleteComputeVM permanently destroys a physical Data Plane compute instance.
 func (sm *ServiceManager) DeleteComputeVM(containerName string) error {
 	log.Printf("[Orchestrator] Tearing down Data Plane VM: %s", containerName)
-	
+
 	stopURL := fmt.Sprintf("http://localhost/containers/%s/stop?t=2", containerName)
 	req, _ := http.NewRequest("POST", stopURL, nil)
 	sm.dockerClient.Do(req)
@@ -734,6 +848,10 @@ func (sm *ServiceManager) DeleteComputeVM(containerName string) error {
 		return err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode >= 400 && resp.StatusCode != http.StatusNotFound {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("remove container %q rejected %d: %s", containerName, resp.StatusCode, b)
+	}
 	return nil
 }
 
@@ -754,7 +872,7 @@ func (sm *ServiceManager) ProvisionServerlessVM(resourceName string, image strin
 			expPort: struct{}{},
 		},
 		"HostConfig": map[string]interface{}{
-			"NetworkMode":  networkName,
+			"NetworkMode": networkName,
 			"PortBindings": map[string]interface{}{
 				expPort: []map[string]string{
 					{"HostIp": "127.0.0.1", "HostPort": "0"},
@@ -817,9 +935,9 @@ func (sm *ServiceManager) fetchLogs(url string) (string, error) {
 		return "Log source not found.", nil
 	}
 
-	// Docker logs stream format: [8]byte header + payload. 
+	// Docker logs stream format: [8]byte header + payload.
 	body, _ := io.ReadAll(resp.Body)
-	
+
 	// Quick header strip for standard docker logs stream headers (8 bytes)
 	var result strings.Builder
 	for i := 0; i < len(body); {
@@ -886,7 +1004,7 @@ func (sm *ServiceManager) RunCommandInContainer(name string, cmd []string) (stri
 
 	// 3. Collect output (Docker stream format)
 	rawOutput, _ := io.ReadAll(startResp.Body)
-	
+
 	// Helper to strip headers
 	var result strings.Builder
 	for i := 0; i < len(rawOutput); {
@@ -997,7 +1115,7 @@ func (sm *ServiceManager) waitUntilReady(addr string, timeout time.Duration) err
 // ─────────────────────────────────────────────────────────────────────────────
 
 func (sm *ServiceManager) CreateVPCNetwork(ctx context.Context, name string) error {
-	netName := "minisky-vpc-" + name
+	netName := DockerNetworkNameForVPC(name)
 	log.Printf("[Orchestrator] Creating VPC Docker network '%s'", netName)
 	payload := map[string]interface{}{
 		"Name":   netName,
@@ -1020,7 +1138,7 @@ func (sm *ServiceManager) CreateVPCNetwork(ctx context.Context, name string) err
 }
 
 func (sm *ServiceManager) DeleteVPCNetwork(ctx context.Context, name string) error {
-	netName := "minisky-vpc-" + name
+	netName := DockerNetworkNameForVPC(name)
 	log.Printf("[Orchestrator] Deleting VPC Docker network '%s'", netName)
 	req, _ := http.NewRequestWithContext(ctx, "DELETE", "http://localhost/networks/"+netName, nil)
 	resp, err := sm.dockerClient.Do(req)
@@ -1038,22 +1156,50 @@ func (sm *ServiceManager) DeleteVPCNetwork(ctx context.Context, name string) err
 // Level 2: Port Binding & Firewall Re-application
 // ─────────────────────────────────────────────────────────────────────────────
 
-func (sm *ServiceManager) updatePortRegistry(containerName string) error {
-	resp, err := sm.dockerClient.Get(fmt.Sprintf("http://localhost/containers/%s/json", containerName))
-	if err != nil {
-		return err
+// containerInspectInfo is the subset of Docker's container-inspect response
+// (GET /containers/{name}/json) that ServiceManager cares about. Every
+// caller that needs it goes through inspectContainer instead of issuing its
+// own HTTP call + decode, so the non-2xx status check only has to live in
+// one place.
+type containerInspectInfo struct {
+	HostConfig struct {
+		NetworkMode string
 	}
-	defer resp.Body.Close()
-
-	var info struct {
-		NetworkSettings struct {
-			Ports map[string][]struct {
-				HostIp   string
-				HostPort string
-			}
+	NetworkSettings struct {
+		Networks map[string]struct {
+			IPAddress string
+		}
+		Ports map[string][]struct {
+			HostIp   string
+			HostPort string
 		}
 	}
+}
+
+// inspectContainer fetches and decodes a container's Docker inspect response.
+// It returns an error for both connection failures and non-2xx responses —
+// a 404/5xx JSON error body would otherwise decode "successfully" into a
+// zero-valued containerInspectInfo, masking the failure as an empty result.
+func (sm *ServiceManager) inspectContainer(containerName string) (*containerInspectInfo, error) {
+	resp, err := sm.dockerClient.Get(fmt.Sprintf("http://localhost/containers/%s/json", containerName))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("inspect %q failed %d: %s", containerName, resp.StatusCode, b)
+	}
+	var info containerInspectInfo
 	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+func (sm *ServiceManager) updatePortRegistry(containerName string) error {
+	info, err := sm.inspectContainer(containerName)
+	if err != nil {
 		return err
 	}
 
@@ -1086,26 +1232,107 @@ func (sm *ServiceManager) GetVMPortMappings(containerName string) []PortMapping 
 }
 
 func (sm *ServiceManager) ApplyFirewallPortsToVPC(vpcName string, containerNames []string, osImages []string) error {
-	allowedPorts := []string{}
+	log.Printf("[Orchestrator] Applying firewall change for VPC '%s' (recreating %d VMs)", vpcName, len(containerNames))
+	for i, cName := range containerNames {
+		osImage := osImages[i]
+
+		// Capture every network cName is currently attached to before tearing it
+		// down. Prefer what ProvisionComputeVM recorded at provision time
+		// (cheap, no Docker round-trip); fall back to asking Docker directly for
+		// containers minisky doesn't have in-memory state for (e.g. it was
+		// restarted since this container was provisioned).
+		vpcNames := sm.registeredVPCNames(cName)
+		if vpcNames == nil {
+			var err error
+			vpcNames, err = sm.attachedVPCNames(cName)
+			if err != nil {
+				log.Printf("[Orchestrator] could not determine attached VPCs for '%s', skipping firewall recreate to avoid dropping its other network memberships: %v", cName, err)
+				continue
+			}
+		}
+		if len(vpcNames) == 0 {
+			vpcNames = []string{vpcName}
+		}
+
+		// Merge ingress-allow ports across every attached VPC, not just the one
+		// whose rules changed — mirrors how a real GCE VM inherits firewall rules
+		// from every network it's attached to.
+		allowedPorts := MergeUniquePorts(vpcNames, sm.allowedPortsForVPC)
+
+		log.Printf("[Orchestrator] Recreating '%s' with ports %v on vpcs %v", cName, allowedPorts, vpcNames)
+		if err := sm.DeleteComputeVM(cName); err != nil {
+			log.Printf("[Orchestrator] failed to delete '%s' before firewall recreate: %v", cName, err)
+		}
+		if err := sm.ProvisionComputeVM(cName, osImage, vpcNames, allowedPorts, []string{}, []string{"tail", "-f", "/dev/null"}); err != nil {
+			log.Printf("[Orchestrator] failed to recreate '%s' after firewall change, it may now be missing: %v", cName, err)
+		}
+	}
+	return nil
+}
+
+// registeredVPCNames returns the VPC names ProvisionComputeVM last recorded
+// for containerName, or nil if minisky has no in-memory record of it.
+func (sm *ServiceManager) registeredVPCNames(containerName string) []string {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	return sm.vpcRegistry[containerName]
+}
+
+// allowedPortsForVPC returns the ingress-allow ports for a single VPC's firewall rules.
+func (sm *ServiceManager) allowedPortsForVPC(vpcName string) []string {
 	sm.mu.RLock()
 	rules := sm.fwRules[vpcName]
 	sm.mu.RUnlock()
 
+	var ports []string
 	for _, r := range rules {
 		if r.Action == "allow" && r.Direction == "INGRESS" {
-			for _, p := range r.Ports {
-				allowedPorts = append(allowedPorts, p)
+			ports = append(ports, r.Ports...)
+		}
+	}
+	return ports
+}
+
+// attachedVPCNames inspects a running container's Docker networks and translates
+// each one back into the VPC name ProvisionComputeVM understands (the inverse of
+// the netMode derivation there), so a firewall-triggered recreate can reattach
+// every network the container had, not just the one whose rules changed.
+//
+// The result is sorted, with the container's original primary network (its
+// HostConfig.NetworkMode at creation time) moved to the front — Docker's own
+// NetworkSettings.Networks is a map, so iterating it directly would make
+// vpcNames[0] (and thus the primary network on the next recreate) change
+// randomly from one call to the next.
+//
+// An error is returned (rather than an empty slice) when the container's
+// networks couldn't be determined, so callers can distinguish "this container
+// legitimately has no recognized VPCs attached" from "we failed to find out" —
+// conflating the two would silently drop VPC membership on a transient
+// Docker API hiccup.
+func (sm *ServiceManager) attachedVPCNames(containerName string) ([]string, error) {
+	info, err := sm.inspectContainer(containerName)
+	if err != nil {
+		return nil, err
+	}
+
+	var vpcNames []string
+	for dockerNet := range info.NetworkSettings.Networks {
+		if vpc, ok := VPCNameForDockerNetwork(dockerNet); ok {
+			vpcNames = append(vpcNames, vpc)
+		}
+	}
+	sort.Strings(vpcNames)
+
+	if primaryVpc, ok := VPCNameForDockerNetwork(info.HostConfig.NetworkMode); ok {
+		for i, v := range vpcNames {
+			if v == primaryVpc {
+				vpcNames[0], vpcNames[i] = vpcNames[i], vpcNames[0]
+				break
 			}
 		}
 	}
 
-	log.Printf("[Orchestrator] Applying firewall ports %v to VPC '%s' (recreating %d VMs)", allowedPorts, vpcName, len(containerNames))
-	for i, cName := range containerNames {
-		osImage := osImages[i]
-		sm.DeleteComputeVM(cName)
-		sm.ProvisionComputeVM(cName, osImage, vpcName, allowedPorts, []string{}, []string{"tail", "-f", "/dev/null"})
-	}
-	return nil
+	return vpcNames, nil
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1137,7 +1364,7 @@ func (sm *ServiceManager) CheckFirewallAllows(vpcName, protocol, port, sourceIP 
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
 	rules := sm.fwRules[vpcName]
-	
+
 	allowed := false
 	for _, r := range rules {
 		if r.Direction == "INGRESS" {
@@ -1251,42 +1478,81 @@ func (b *bufferedConn) Read(p []byte) (int, error) {
 	return b.r.Read(p)
 }
 
-
-func (sm *ServiceManager) DoDockerRequest(req *http.Request) (*http.Response, error) { 
-	return sm.dockerClient.Do(req) 
+func (sm *ServiceManager) DoDockerRequest(req *http.Request) (*http.Response, error) {
+	return sm.dockerClient.Do(req)
 }
-// GetContainerIP retrieves the internal IP address of a container.
-func (sm *ServiceManager) GetContainerIP(name string) string {
-	resp, err := sm.dockerClient.Get(fmt.Sprintf("http://localhost/containers/%s/json", name))
+
+// GetContainerNetworks fetches a container's Docker network membership in a
+// single inspect call, returning a map of Docker network name -> IP address
+// on that network. Callers that need the IP on more than one network (e.g. a
+// multi-NIC VM) should call this once and look up each network locally,
+// rather than issuing one inspect per network.
+func (sm *ServiceManager) GetContainerNetworks(containerName string) (map[string]string, error) {
+	info, err := sm.inspectContainer(containerName)
 	if err != nil {
-		return ""
+		return nil, err
+	}
+
+	ips := make(map[string]string, len(info.NetworkSettings.Networks))
+	for name, n := range info.NetworkSettings.Networks {
+		ips[name] = n.IPAddress
+	}
+	return ips, nil
+}
+
+// GetContainerIPForNetwork retrieves a container's IP on one specific Docker
+// network, so a multi-NIC VM can report the correct address per interface
+// instead of collapsing every interface onto a single network's IP.
+func (sm *ServiceManager) GetContainerIPForNetwork(containerName string, dockerNetworkName string) (string, error) {
+	ips, err := sm.GetContainerNetworks(containerName)
+	if err != nil {
+		return "", err
+	}
+	return ips[dockerNetworkName], nil
+}
+
+// ConnectContainerToNetwork attaches an already-running container to an additional
+// Docker network. Docker's /containers/create only accepts one network at creation
+// time (see netMode in ProvisionComputeVM above); every network past the first has
+// to be attached after the fact through this endpoint.
+func (sm *ServiceManager) ConnectContainerToNetwork(containerName string, vpcName string) error {
+	dockerNetworkName := DockerNetworkNameForVPC(vpcName)
+	payload := map[string]interface{}{
+		"Container": containerName,
+	}
+	body, _ := json.Marshal(payload)
+	connectUrl := fmt.Sprintf("http://localhost/networks/%s/connect", dockerNetworkName)
+	resp, err := sm.dockerClient.Post(connectUrl, "application/json", bytes.NewBuffer(body))
+	if err != nil {
+		return err
 	}
 	defer resp.Body.Close()
-
-	var info struct {
-		NetworkSettings struct {
-			Networks map[string]struct {
-				IPAddress string
-			}
+	if resp.StatusCode >= 400 {
+		b, _ := io.ReadAll(resp.Body)
+		// Docker rejects connecting a container that's already a member of the target
+		// network. ProvisionComputeVM's caller can legitimately hit this on a
+		// retried/duplicate provision call for the same containerName+vpcNames — real
+		// GCE APIs are idempotent under retry, so treat "already attached" the same
+		// way: a no-op success, not a failure that should roll back an
+		// otherwise-healthy container.
+		if isAlreadyAttachedError(string(b)) {
+			return nil
 		}
+		return fmt.Errorf("connect failed %d: %s", resp.StatusCode, b)
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
-		return ""
-	}
+	return nil
+}
 
-	// Prioritize minisky-net
-	if net, ok := info.NetworkSettings.Networks[networkName]; ok && net.IPAddress != "" {
-		return net.IPAddress
-	}
-
-	// Fallback to first available IP
-	for _, net := range info.NetworkSettings.Networks {
-		if net.IPAddress != "" {
-			return net.IPAddress
-		}
-	}
-
-	return ""
+// isAlreadyAttachedError reports whether a Docker network-connect error body
+// indicates the container is already a member of the target network, rather
+// than a genuine failure (network missing, daemon unreachable, etc.). Docker
+// has mapped this case to different HTTP status codes across engine
+// versions, so the message text is the more stable signal to match on.
+func isAlreadyAttachedError(msg string) bool {
+	lower := strings.ToLower(msg)
+	return strings.Contains(lower, "already exists in network") ||
+		strings.Contains(lower, "already connected to network") ||
+		strings.Contains(lower, "endpoint with name")
 }
 
 type ContainerSummary struct {
@@ -1355,8 +1621,8 @@ func (sm *ServiceManager) GetContainerStats(name string) (*ContainerStats, error
 			SystemCPUUsage uint64 `json:"system_cpu_usage"`
 		} `json:"precpu_stats"`
 		MemoryStats struct {
-			Usage    uint64 `json:"usage"`
-			Stats    map[string]uint64 `json:"stats"`
+			Usage uint64            `json:"usage"`
+			Stats map[string]uint64 `json:"stats"`
 		} `json:"memory_stats"`
 	}
 

--- a/pkg/orchestrator/manager_test.go
+++ b/pkg/orchestrator/manager_test.go
@@ -1,0 +1,531 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// fakeTransport routes requests to a handler so tests can fake the Docker
+// daemon's HTTP API without a real socket.
+type fakeTransport struct {
+	handler func(req *http.Request) (*http.Response, error)
+	calls   []string // "METHOD path", in order, for assertions
+}
+
+func (f *fakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	f.calls = append(f.calls, req.Method+" "+req.URL.Path)
+	return f.handler(req)
+}
+
+func jsonResp(status int, body string) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func TestAttachedVPCNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		status   int
+		reqErr   bool
+		expected []string
+		wantErr  bool
+	}{
+		{
+			name:     "default network maps to default vpc name",
+			body:     `{"NetworkSettings":{"Networks":{"minisky-net":{}}}}`,
+			expected: []string{"default"},
+		},
+		{
+			name:     "vpc network maps back to its vpc name",
+			body:     `{"NetworkSettings":{"Networks":{"minisky-vpc-shared":{}}}}`,
+			expected: []string{"shared"},
+		},
+		{
+			name:     "unrecognized networks are ignored",
+			body:     `{"NetworkSettings":{"Networks":{"bridge":{}}}}`,
+			expected: nil,
+		},
+		{
+			name:     "no networks attached",
+			body:     `{"NetworkSettings":{"Networks":{}}}`,
+			expected: nil,
+		},
+		{
+			name:    "request error is propagated, not swallowed as empty",
+			reqErr:  true,
+			wantErr: true,
+		},
+		{
+			name:    "decode error is propagated, not swallowed as empty",
+			body:    `not json`,
+			wantErr: true,
+		},
+		{
+			name:    "non-2xx status with a well-formed JSON error body is an error, not an empty result",
+			body:    `{"message":"no such container"}`,
+			status:  http.StatusNotFound,
+			wantErr: true,
+		},
+		{
+			name: "primary network (HostConfig.NetworkMode) is sorted to the front",
+			body: `{"HostConfig":{"NetworkMode":"minisky-vpc-prod"},"NetworkSettings":{"Networks":{
+				"minisky-net": {}, "minisky-vpc-prod": {}, "minisky-vpc-shared": {}
+			}}}`,
+			expected: []string{"prod", "default", "shared"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ft := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+				if tt.reqErr {
+					return nil, fmt.Errorf("boom")
+				}
+				status := tt.status
+				if status == 0 {
+					status = http.StatusOK
+				}
+				return jsonResp(status, tt.body)
+			}}
+			sm := NewServiceManagerForTesting(ft)
+
+			got, err := sm.attachedVPCNames("some-container")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got nil (got vpcNames %v)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.expected) {
+				t.Fatalf("got %v, want %v", got, tt.expected)
+			}
+			if tt.name == "primary network (HostConfig.NetworkMode) is sorted to the front" {
+				if len(got) == 0 || got[0] != "prod" {
+					t.Errorf("got %v, want primary vpc %q first", got, "prod")
+				}
+				return
+			}
+			seen := map[string]bool{}
+			for _, v := range got {
+				seen[v] = true
+			}
+			for _, v := range tt.expected {
+				if !seen[v] {
+					t.Errorf("missing expected vpc name %q in %v", v, got)
+				}
+			}
+		})
+	}
+}
+
+func TestGetContainerIPForNetwork(t *testing.T) {
+	body := `{"NetworkSettings":{"Networks":{
+		"minisky-net": {"IPAddress": "172.18.0.2"},
+		"minisky-vpc-shared": {"IPAddress": "172.19.0.5"}
+	}}}`
+
+	ft := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+		return jsonResp(http.StatusOK, body)
+	}}
+	sm := NewServiceManagerForTesting(ft)
+
+	ip, err := sm.GetContainerIPForNetwork("my-vm", "minisky-vpc-shared")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ip != "172.19.0.5" {
+		t.Errorf("got IP %q, want 172.19.0.5", ip)
+	}
+
+	// A network the container isn't attached to should come back empty, not error.
+	ip, err = sm.GetContainerIPForNetwork("my-vm", "minisky-vpc-not-attached-yet")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ip != "" {
+		t.Errorf("got IP %q for unattached network, want empty string", ip)
+	}
+}
+
+func TestConnectContainerToNetwork(t *testing.T) {
+	tests := []struct {
+		name       string
+		vpcName    string
+		wantURLSeg string
+	}{
+		{name: "empty vpc uses shared network", vpcName: "", wantURLSeg: "/networks/minisky-net/connect"},
+		{name: "default vpc uses shared network", vpcName: "default", wantURLSeg: "/networks/minisky-net/connect"},
+		{name: "named vpc gets its own network", vpcName: "shared", wantURLSeg: "/networks/minisky-vpc-shared/connect"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPath string
+			ft := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+				gotPath = req.URL.Path
+				return jsonResp(http.StatusOK, "{}")
+			}}
+			sm := NewServiceManagerForTesting(ft)
+
+			if err := sm.ConnectContainerToNetwork("my-vm", tt.vpcName); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotPath != tt.wantURLSeg {
+				t.Errorf("got path %q, want %q", gotPath, tt.wantURLSeg)
+			}
+		})
+	}
+
+	t.Run("docker error response is surfaced", func(t *testing.T) {
+		ft := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+			return jsonResp(http.StatusInternalServerError, "network not found")
+		}}
+		sm := NewServiceManagerForTesting(ft)
+
+		if err := sm.ConnectContainerToNetwork("my-vm", "shared"); err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+	})
+
+	t.Run("already-attached is treated as a no-op success, not an error", func(t *testing.T) {
+		// A retried/duplicate ProvisionComputeVM call for a container that's already
+		// on this network should not be treated as a failure that rolls back an
+		// otherwise-healthy container.
+		ft := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+			return jsonResp(http.StatusForbidden, `{"message":"endpoint with name my-vm already exists in network minisky-vpc-shared"}`)
+		}}
+		sm := NewServiceManagerForTesting(ft)
+
+		if err := sm.ConnectContainerToNetwork("my-vm", "shared"); err != nil {
+			t.Fatalf("expected already-attached to be treated as success, got error: %v", err)
+		}
+	})
+
+	t.Run("transport error does not panic on nil response", func(t *testing.T) {
+		ft := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+			return nil, fmt.Errorf("connection refused")
+		}}
+		sm := NewServiceManagerForTesting(ft)
+
+		if err := sm.ConnectContainerToNetwork("my-vm", "shared"); err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+	})
+}
+
+func TestAllowedPortsForVPC(t *testing.T) {
+	sm := NewServiceManagerForTesting(&fakeTransport{})
+	sm.RegisterFirewallRule("shared", FirewallEntry{Direction: "INGRESS", Action: "allow", Ports: []string{"80", "443"}})
+	sm.RegisterFirewallRule("shared", FirewallEntry{Direction: "EGRESS", Action: "allow", Ports: []string{"9999"}})
+	sm.RegisterFirewallRule("shared", FirewallEntry{Direction: "INGRESS", Action: "deny", Ports: []string{"22"}})
+
+	got := sm.allowedPortsForVPC("shared")
+	want := map[string]bool{"80": true, "443": true}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want ports %v", got, want)
+	}
+	for _, p := range got {
+		if !want[p] {
+			t.Errorf("unexpected port %q in %v", p, got)
+		}
+	}
+}
+
+func TestApplyFirewallPortsToVPC_PrefersRegisteredVPCsOverDockerInspect(t *testing.T) {
+	ft := dockerFakeForProvision(t, "")
+	sm := NewServiceManagerForTesting(ft)
+
+	// Provisioning records "my-vm" -> ["default", "shared"] in the in-memory
+	// vpcRegistry.
+	if err := sm.ProvisionComputeVM("my-vm", "ubuntu:latest", []string{"default", "shared"}, nil, nil, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	sm.RegisterFirewallRule("shared", FirewallEntry{Direction: "INGRESS", Action: "allow", Ports: []string{"8080"}})
+
+	ft.calls = nil // only count calls made by ApplyFirewallPortsToVPC itself
+	if err := sm.ApplyFirewallPortsToVPC("shared", []string{"my-vm"}, []string{"ubuntu:latest"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var inspects int
+	for _, c := range ft.calls {
+		if strings.HasPrefix(c, "GET /containers/") && strings.HasSuffix(c, "/json") {
+			inspects++
+		}
+	}
+	// Exactly one container inspect: the post-recreate port-registry update. If the
+	// registry weren't consulted, attachedVPCNames would add a second inspect
+	// before delete.
+	if inspects != 1 {
+		t.Errorf("got %d container inspect calls, want 1 (registry should avoid the attachedVPCNames Docker round-trip): calls=%v", inspects, ft.calls)
+	}
+}
+
+func TestApplyFirewallPortsToVPC_FallsBackToDockerInspectWhenNotRegistered(t *testing.T) {
+	ft := dockerFakeForProvision(t, "")
+	sm := NewServiceManagerForTesting(ft)
+	// No ProvisionComputeVM call — vpcRegistry has no entry for "my-vm", simulating
+	// a container that was provisioned before minisky's process last restarted.
+
+	sm.RegisterFirewallRule("shared", FirewallEntry{Direction: "INGRESS", Action: "allow", Ports: []string{"8080"}})
+
+	if err := sm.ApplyFirewallPortsToVPC("shared", []string{"my-vm"}, []string{"ubuntu:latest"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var inspects int
+	for _, c := range ft.calls {
+		if strings.HasPrefix(c, "GET /containers/") && strings.HasSuffix(c, "/json") {
+			inspects++
+		}
+	}
+	if inspects < 2 {
+		t.Errorf("got %d container inspect calls, want at least 2 (attachedVPCNames fallback + post-recreate port registry): calls=%v", inspects, ft.calls)
+	}
+}
+
+// dockerFakeForProvision fakes the sequence of Docker calls ProvisionComputeVM
+// makes: create, start, connect (once per extra network), then an inspect for
+// the port-registry update.
+func dockerFakeForProvision(t *testing.T, failConnectForNetwork string) *fakeTransport {
+	t.Helper()
+	return &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == "POST" && strings.HasPrefix(req.URL.Path, "/containers/create"):
+			return jsonResp(http.StatusCreated, `{"Id":"abc123"}`)
+		case req.Method == "POST" && strings.HasSuffix(req.URL.Path, "/start"):
+			return jsonResp(http.StatusNoContent, "")
+		case req.Method == "POST" && strings.HasSuffix(req.URL.Path, "/connect"):
+			if failConnectForNetwork != "" && strings.Contains(req.URL.Path, failConnectForNetwork) {
+				return jsonResp(http.StatusInternalServerError, "connect failed")
+			}
+			return jsonResp(http.StatusOK, "{}")
+		case req.Method == "POST" && strings.HasSuffix(req.URL.Path, "/stop"):
+			return jsonResp(http.StatusNoContent, "")
+		case req.Method == "DELETE":
+			return jsonResp(http.StatusNoContent, "")
+		case req.Method == "GET" && strings.HasSuffix(req.URL.Path, "/json"):
+			return jsonResp(http.StatusOK, `{"NetworkSettings":{"Ports":{}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	}}
+}
+
+func TestProvisionComputeVM_EmptyVpcNamesDoesNotPanic(t *testing.T) {
+	ft := dockerFakeForProvision(t, "")
+	sm := NewServiceManagerForTesting(ft)
+
+	if err := sm.ProvisionComputeVM("my-vm", "ubuntu:latest", nil, nil, nil, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, c := range ft.calls {
+		if strings.HasSuffix(c, "/connect") {
+			t.Errorf("expected no /connect calls for an empty vpcNames, got call: %s", c)
+		}
+	}
+}
+
+func TestProvisionComputeVM_DedupsDuplicateVPCs(t *testing.T) {
+	ft := dockerFakeForProvision(t, "")
+	sm := NewServiceManagerForTesting(ft)
+
+	// Two network interfaces both pointing at "default" used to try to
+	// ConnectContainerToNetwork the primary network a second time, which a
+	// real Docker daemon rejects as already-attached and rolls back an
+	// otherwise-healthy container.
+	err := sm.ProvisionComputeVM("my-vm", "ubuntu:latest", []string{"default", "default", "shared"}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var connects int
+	for _, c := range ft.calls {
+		if strings.HasSuffix(c, "/connect") {
+			connects++
+		}
+	}
+	if connects != 1 {
+		t.Errorf("got %d /connect calls, want 1 (duplicate 'default' entry should be deduped)", connects)
+	}
+	for _, c := range ft.calls {
+		if strings.HasPrefix(c, "DELETE") {
+			t.Errorf("did not expect a rollback DELETE call, calls were: %v", ft.calls)
+		}
+	}
+}
+
+func TestProvisionComputeVM_AttachesEveryNetwork(t *testing.T) {
+	ft := dockerFakeForProvision(t, "")
+	sm := NewServiceManagerForTesting(ft)
+
+	err := sm.ProvisionComputeVM("my-vm", "ubuntu:latest", []string{"default", "shared", "prod"}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var connects int
+	for _, c := range ft.calls {
+		if strings.HasSuffix(c, "/connect") {
+			connects++
+		}
+	}
+	if connects != 2 {
+		t.Errorf("got %d /connect calls, want 2 (one per network past the primary)", connects)
+	}
+}
+
+func TestProvisionComputeVM_RollsBackOnAttachFailure(t *testing.T) {
+	ft := dockerFakeForProvision(t, "minisky-vpc-prod")
+	sm := NewServiceManagerForTesting(ft)
+
+	err := sm.ProvisionComputeVM("my-vm", "ubuntu:latest", []string{"default", "prod"}, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected an error when a network attach fails, got nil")
+	}
+
+	var sawDelete bool
+	for _, c := range ft.calls {
+		if strings.HasPrefix(c, "DELETE") {
+			sawDelete = true
+		}
+	}
+	if !sawDelete {
+		t.Errorf("expected a rollback DELETE call after attach failure, calls were: %v", ft.calls)
+	}
+}
+
+func TestCreateAndDeleteVPCNetwork_UseSharedNamingScheme(t *testing.T) {
+	var gotPaths []string
+	ft := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+		gotPaths = append(gotPaths, req.Method+" "+req.URL.Path)
+		return jsonResp(http.StatusOK, "{}")
+	}}
+	sm := NewServiceManagerForTesting(ft)
+
+	if err := sm.CreateVPCNetwork(context.Background(), "shared"); err != nil {
+		t.Fatalf("CreateVPCNetwork: unexpected error: %v", err)
+	}
+	if err := sm.DeleteVPCNetwork(context.Background(), "shared"); err != nil {
+		t.Fatalf("DeleteVPCNetwork: unexpected error: %v", err)
+	}
+
+	want := []string{"POST /networks/create", "DELETE /networks/" + DockerNetworkNameForVPC("shared")}
+	if len(gotPaths) != len(want) || gotPaths[0] != want[0] || gotPaths[1] != want[1] {
+		t.Errorf("got calls %v, want %v", gotPaths, want)
+	}
+}
+
+func TestProvisionComputeVM_RollsBackOnStartFailure(t *testing.T) {
+	ft := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == "GET" && strings.HasPrefix(req.URL.Path, "/images/"):
+			return jsonResp(http.StatusOK, "{}")
+		case req.Method == "POST" && strings.HasPrefix(req.URL.Path, "/containers/create"):
+			return jsonResp(http.StatusCreated, `{"Id":"abc123"}`)
+		case req.Method == "POST" && strings.HasSuffix(req.URL.Path, "/start"):
+			return jsonResp(http.StatusInternalServerError, "start failed")
+		case req.Method == "POST" && strings.HasSuffix(req.URL.Path, "/stop"):
+			return jsonResp(http.StatusNoContent, "")
+		case req.Method == "DELETE":
+			return jsonResp(http.StatusNoContent, "")
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	}}
+	sm := NewServiceManagerForTesting(ft)
+
+	err := sm.ProvisionComputeVM("my-vm", "ubuntu:latest", []string{"default"}, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected an error when container start fails, got nil")
+	}
+
+	var sawDelete bool
+	for _, c := range ft.calls {
+		if strings.HasPrefix(c, "DELETE") {
+			sawDelete = true
+		}
+	}
+	if !sawDelete {
+		t.Errorf("expected a rollback DELETE call after start failure, calls were: %v", ft.calls)
+	}
+}
+
+func TestStopAndRemoveContainer(t *testing.T) {
+	tests := []struct {
+		name         string
+		removeStatus int
+		wantErr      bool
+	}{
+		{name: "successful removal", removeStatus: http.StatusNoContent, wantErr: false},
+		{name: "container already gone (404) is not an error", removeStatus: http.StatusNotFound, wantErr: false},
+		{name: "docker rejects removal, error is surfaced", removeStatus: http.StatusInternalServerError, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ft := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+				if req.Method == "DELETE" {
+					return jsonResp(tt.removeStatus, "")
+				}
+				return jsonResp(http.StatusNoContent, "")
+			}}
+			sm := NewServiceManagerForTesting(ft)
+
+			err := sm.StopAndRemoveContainer("my-vm")
+			if tt.wantErr && err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestDeleteComputeVM(t *testing.T) {
+	tests := []struct {
+		name         string
+		removeStatus int
+		wantErr      bool
+	}{
+		{name: "successful removal", removeStatus: http.StatusNoContent, wantErr: false},
+		{name: "container already gone (404) is not an error", removeStatus: http.StatusNotFound, wantErr: false},
+		{name: "docker rejects removal, error is surfaced", removeStatus: http.StatusInternalServerError, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ft := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+				if req.Method == "DELETE" {
+					return jsonResp(tt.removeStatus, "")
+				}
+				return jsonResp(http.StatusNoContent, "")
+			}}
+			sm := NewServiceManagerForTesting(ft)
+
+			err := sm.DeleteComputeVM("my-vm")
+			if tt.wantErr && err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/shims/compute/api.go
+++ b/pkg/shims/compute/api.go
@@ -25,27 +25,27 @@ func init() {
 
 // Instance represents a GCE VM with its full lifecycle state.
 type Instance struct {
-	Kind              string            `json:"kind"`
-	ID                string            `json:"id"`
-	Name              string            `json:"name"`
-	Zone              string            `json:"zone"`
-	MachineType       string            `json:"machineType"`
-	Status            string            `json:"status"`
-	SelfLink          string            `json:"selfLink"`
-	Description       string            `json:"description"`
-	Labels            map[string]string `json:"labels,omitempty"`
-	Metadata          *InstanceMetadata `json:"metadata,omitempty"`
-	NetworkInterfaces []NetworkInterface `json:"networkInterfaces"`
-	Disks             []AttachedDisk    `json:"disks"`
-	CreationTimestamp string            `json:"creationTimestamp"`
+	Kind              string                     `json:"kind"`
+	ID                string                     `json:"id"`
+	Name              string                     `json:"name"`
+	Zone              string                     `json:"zone"`
+	MachineType       string                     `json:"machineType"`
+	Status            string                     `json:"status"`
+	SelfLink          string                     `json:"selfLink"`
+	Description       string                     `json:"description"`
+	Labels            map[string]string          `json:"labels,omitempty"`
+	Metadata          *InstanceMetadata          `json:"metadata,omitempty"`
+	NetworkInterfaces []NetworkInterface         `json:"networkInterfaces"`
+	Disks             []AttachedDisk             `json:"disks"`
+	CreationTimestamp string                     `json:"creationTimestamp"`
 	HostPorts         []orchestrator.PortMapping `json:"hostPorts,omitempty"`
 	// internal tracking only
-	project string
-	zone    string
-	Fingerprint string `json:"fingerprint"`
-	LabelFingerprint  string            `json:"labelFingerprint"`
-	Scheduling        *Scheduling       `json:"scheduling,omitempty"`
-	CanIpForward      bool              `json:"canIpForward"`
+	project          string
+	zone             string
+	Fingerprint      string      `json:"fingerprint"`
+	LabelFingerprint string      `json:"labelFingerprint"`
+	Scheduling       *Scheduling `json:"scheduling,omitempty"`
+	CanIpForward     bool        `json:"canIpForward"`
 }
 
 func (i *Instance) DeepCopy() *Instance {
@@ -92,8 +92,8 @@ type Scheduling struct {
 }
 
 type InstanceMetadata struct {
-	Kind  string            `json:"kind"`
-	Items []MetadataItem    `json:"items,omitempty"`
+	Kind  string         `json:"kind"`
+	Items []MetadataItem `json:"items,omitempty"`
 }
 
 type MetadataItem struct {
@@ -150,14 +150,14 @@ type SecurityPolicy struct {
 }
 
 type SecurityPolicyRule struct {
-	Priority    int             `json:"priority"`
-	Action      string          `json:"action"`
-	Description string          `json:"description,omitempty"`
-	Match       *RuleMatch      `json:"match,omitempty"`
+	Priority    int        `json:"priority"`
+	Action      string     `json:"action"`
+	Description string     `json:"description,omitempty"`
+	Match       *RuleMatch `json:"match,omitempty"`
 }
 
 type RuleMatch struct {
-	VersionedExpr string `json:"versionedExpr,omitempty"` // SRC_IPS_V1
+	VersionedExpr string           `json:"versionedExpr,omitempty"` // SRC_IPS_V1
 	Config        *RuleMatchConfig `json:"config,omitempty"`
 }
 
@@ -173,8 +173,8 @@ type FirewallRule struct {
 	Description       string          `json:"description,omitempty"`
 	Network           string          `json:"network"`
 	Priority          int             `json:"priority"`
-	Direction         string          `json:"direction"`   // INGRESS, EGRESS
-	Action            string          `json:"action"`      // allow, deny
+	Direction         string          `json:"direction"` // INGRESS, EGRESS
+	Action            string          `json:"action"`    // allow, deny
 	SourceRanges      []string        `json:"sourceRanges,omitempty"`
 	DestinationRanges []string        `json:"destinationRanges,omitempty"`
 	Allowed           []FirewallAllow `json:"allowed,omitempty"`
@@ -199,10 +199,10 @@ type API struct {
 	mu               sync.RWMutex
 	opMgr            *orchestrator.OperationManager
 	svcMgr           *orchestrator.ServiceManager
-	instances        map[string]*Instance        // key: project+":"+zone+":"+name
-	networks         map[string]*Network         // key: project+":"+name
-	securityPolicies map[string]*SecurityPolicy  // key: project+":"+name
-	firewalls        map[string]*FirewallRule     // key: project+":"+name
+	instances        map[string]*Instance       // key: project+":"+zone+":"+name
+	networks         map[string]*Network        // key: project+":"+name
+	securityPolicies map[string]*SecurityPolicy // key: project+":"+name
+	firewalls        map[string]*FirewallRule   // key: project+":"+name
 }
 
 // NewAPI builds the Compute shim with the shared LRO manager and service manager.
@@ -224,7 +224,7 @@ func NewAPI(opMgr *orchestrator.OperationManager, svcMgr *orchestrator.ServiceMa
 func (api *API) ListProjects() []string {
 	api.mu.RLock()
 	defer api.mu.RUnlock()
-	
+
 	projects := make(map[string]bool)
 	for _, inst := range api.instances {
 		if inst.project != "" {
@@ -239,7 +239,7 @@ func (api *API) ListProjects() []string {
 		p := strings.Split(k, ":")[0]
 		projects[p] = true
 	}
-	
+
 	res := []string{}
 	for p := range projects {
 		res = append(res, p)
@@ -321,20 +321,19 @@ func (api *API) routeInstances(w http.ResponseWriter, r *http.Request, path stri
 // Creates an in-memory instance in PROVISIONING state and kicks off an LRO.
 func (api *API) insertInstance(w http.ResponseWriter, r *http.Request, project, zone string) {
 	var body struct {
-		Name        string `json:"name"`
-		MachineType string `json:"machineType"`
-		Description string `json:"description"`
-		Labels      map[string]string `json:"labels"`
-		Metadata    *InstanceMetadata `json:"metadata"`
+		Name              string             `json:"name"`
+		MachineType       string             `json:"machineType"`
+		Description       string             `json:"description"`
+		Labels            map[string]string  `json:"labels"`
+		Metadata          *InstanceMetadata  `json:"metadata"`
 		NetworkInterfaces []NetworkInterface `json:"networkInterfaces"`
-		Disks       []AttachedDisk `json:"disks"`
+		Disks             []AttachedDisk     `json:"disks"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		writeError(w, 400, "INVALID_ARGUMENT", "Request body parse error: "+err.Error())
 		return
 	}
-
 
 	name := body.Name
 	if name == "" {
@@ -366,6 +365,15 @@ func (api *API) insertInstance(w http.ResponseWriter, r *http.Request, project, 
 			Network:   fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/networks/default", project),
 			NetworkIP: "10.128.0.2",
 		}}
+	}
+
+	// GCE requires every network interface to be on a distinct VPC network —
+	// instances.insert (and thus terraform apply) rejects the request outright
+	// rather than attaching only one of the duplicates.
+	if dup := duplicateNetworkInterfaceVPC(netIfaces); dup != "" {
+		w.WriteHeader(http.StatusBadRequest)
+		writeError(w, 400, "INVALID_ARGUMENT", fmt.Sprintf("Invalid value for field 'resource.networkInterfaces': network %q is used by more than one interface; each interface must be on a different VPC network", dup))
+		return
 	}
 
 	// Default boot disk
@@ -479,23 +487,26 @@ func (api *API) insertInstance(w http.ResponseWriter, r *http.Request, project, 
 		}
 		api.mu.Unlock()
 
-		vpcName := "default"
+		// Build the full list of VPC names, one per network interface, so
+		// ProvisionComputeVM below attaches every network, not just nic0.
+		vpcNames := []string{"default"}
 		api.mu.RLock()
-		if i, ok := api.instances[key]; ok {
-			if len(i.NetworkInterfaces) > 0 {
-				parts := strings.Split(i.NetworkInterfaces[0].Network, "/")
-				if len(parts) > 0 && parts[len(parts)-1] != "" {
-					vpcName = parts[len(parts)-1]
-				}
+		if i, ok := api.instances[key]; ok && len(i.NetworkInterfaces) > 0 {
+			vpcNames = make([]string, len(i.NetworkInterfaces))
+			for j, iface := range i.NetworkInterfaces {
+				vpcNames[j] = networkInterfaceVPCName(iface)
 			}
 		}
 		api.mu.RUnlock()
 
-		allowedPorts := api.getAllowedPortsForVPC(vpcName)
+		// Merge ingress-allow ports across every attached VPC, mirroring how a real
+		// GCE VM inherits firewall rules from all networks it's attached to, not just
+		// the primary one.
+		allowedPorts := orchestrator.MergeUniquePorts(vpcNames, api.getAllowedPortsForVPC)
 
 		// Tell the Orchestrator to physically spin up the Docker container!
-		err := api.svcMgr.ProvisionComputeVM(containerName, osImage, vpcName, allowedPorts, []string{}, []string{"tail", "-f", "/dev/null"})
-		
+		err := api.svcMgr.ProvisionComputeVM(containerName, osImage, vpcNames, allowedPorts, []string{}, []string{"tail", "-f", "/dev/null"})
+
 		api.mu.Lock()
 		if i, ok := api.instances[key]; ok {
 			if err != nil {
@@ -504,7 +515,7 @@ func (api *API) insertInstance(w http.ResponseWriter, r *http.Request, project, 
 				api.mu.Unlock()
 				return err
 			}
-			
+
 			// 3. Post-provisioning delay to ensure the UI catches the transition
 			time.Sleep(1500 * time.Millisecond)
 
@@ -530,7 +541,7 @@ func (api *API) getInstance(w http.ResponseWriter, r *http.Request, project, zon
 		writeError(w, 404, "NOT_FOUND", fmt.Sprintf("Instance '%s' not found in zone '%s'", name, zone))
 		return
 	}
-	
+
 	// Deep copy under lock to avoid racing with background updates
 	instCopy := inst.DeepCopy()
 	api.mu.RUnlock()
@@ -542,16 +553,15 @@ func (api *API) getInstance(w http.ResponseWriter, r *http.Request, project, zon
 	}
 	instCopy.HostPorts = api.svcMgr.GetVMPortMappings(cName)
 	if len(instCopy.NetworkInterfaces) > 0 {
-		ip := api.svcMgr.GetContainerIP(cName)
-		if ip == "" {
-			ip = "10.128.0.2" // Fallback to avoid empty IP which can crash some providers
-		}
-		instCopy.NetworkInterfaces[0].NetworkIP = ip
-		if instCopy.NetworkInterfaces[0].Subnetwork == "" {
-			instCopy.NetworkInterfaces[0].Subnetwork = fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/subnetworks/default", project, strings.Join(strings.Split(zone, "-")[:2], "-"))
+		api.patchNetworkIPs(instCopy, cName)
+		defaultSubnetwork := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/subnetworks/default", project, strings.Join(strings.Split(zone, "-")[:2], "-"))
+		for j := range instCopy.NetworkInterfaces {
+			if instCopy.NetworkInterfaces[j].Subnetwork == "" {
+				instCopy.NetworkInterfaces[j].Subnetwork = defaultSubnetwork
+			}
 		}
 	}
-	
+
 	if instCopy.Fingerprint == "" {
 		instCopy.Fingerprint = "minisky-mock-fingerprint"
 	}
@@ -562,28 +572,39 @@ func (api *API) getInstance(w http.ResponseWriter, r *http.Request, project, zon
 
 func (api *API) listInstances(w http.ResponseWriter, r *http.Request, project, zone string) {
 	prefix := instanceKey(project, zone, "")
-	api.mu.RLock()
-	defer api.mu.RUnlock()
 
-	items := []*Instance{}
+	// Copy the matching instances under lock, then do the (potentially slow,
+	// blocking) Docker lookups below without holding api.mu — otherwise every
+	// insertInstance/deleteInstance writer stalls for the whole loop.
+	api.mu.RLock()
+	var copies []*Instance
 	for k, v := range api.instances {
 		if strings.HasPrefix(k, prefix) {
-			copyOfInst := v.DeepCopy()
+			copies = append(copies, v.DeepCopy())
+		}
+	}
+	api.mu.RUnlock()
+
+	// Each instance's Docker lookups are independent, so fan them out concurrently
+	// instead of paying N sequential Docker round-trips on a UI-polled endpoint.
+	items := make([]*Instance, len(copies))
+	var wg sync.WaitGroup
+	for idx, copyOfInst := range copies {
+		wg.Add(1)
+		go func(idx int, copyOfInst *Instance) {
+			defer wg.Done()
 			cName := "minisky-vm-" + copyOfInst.Name
 			if copyOfInst.Labels != nil && copyOfInst.Labels["managed-by"] == "gke" {
 				cName = copyOfInst.Name
 			}
 			copyOfInst.HostPorts = api.svcMgr.GetVMPortMappings(cName)
 			if len(copyOfInst.NetworkInterfaces) > 0 {
-				ip := api.svcMgr.GetContainerIP(cName)
-				if ip == "" {
-					ip = "10.128.0.2"
-				}
-				copyOfInst.NetworkInterfaces[0].NetworkIP = ip
+				api.patchNetworkIPs(copyOfInst, cName)
 			}
-			items = append(items, copyOfInst)
-		}
+			items[idx] = copyOfInst
+		}(idx, copyOfInst)
 	}
+	wg.Wait()
 
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(map[string]interface{}{
@@ -618,18 +639,18 @@ func (api *API) deleteInstance(w http.ResponseWriter, r *http.Request, project, 
 	containerName := fmt.Sprintf("minisky-vm-%s", name)
 	op := api.opMgr.Register("compute#operation", "delete",
 		selfLinkInstance(project, zone, name), zone, "")
-	
+
 	api.opMgr.RunAsync(op.Name, func() error {
 		// Simulate winding down time
 		time.Sleep(3 * time.Second)
-		
+
 		api.svcMgr.DeleteComputeVM(containerName)
-		
+
 		// Finally remove from memory
 		api.mu.Lock()
 		delete(api.instances, key)
 		api.mu.Unlock()
-		return nil 
+		return nil
 	})
 
 	w.WriteHeader(http.StatusOK)
@@ -823,14 +844,14 @@ func (api *API) routeNetworks(w http.ResponseWriter, r *http.Request, path strin
 			api.mu.RLock()
 			n, ok := api.networks[key]
 			api.mu.RUnlock()
-			
+
 			if !ok && name == "default" {
 				// Return a virtual default network
 				n = &Network{
-					Kind: "compute#network",
-					ID: "0",
-					Name: "default",
-					SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/networks/default", project),
+					Kind:              "compute#network",
+					ID:                "0",
+					Name:              "default",
+					SelfLink:          fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/networks/default", project),
 					CreationTimestamp: "2024-01-01T00:00:00Z",
 				}
 				ok = true
@@ -857,13 +878,13 @@ func (api *API) routeNetworks(w http.ResponseWriter, r *http.Request, path strin
 				}
 			}
 			api.mu.RUnlock()
-			
+
 			if !hasDefault {
 				items = append(items, &Network{
-					Kind: "compute#network",
-					ID: "0",
-					Name: "default",
-					SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/networks/default", project),
+					Kind:              "compute#network",
+					ID:                "0",
+					Name:              "default",
+					SelfLink:          fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/networks/default", project),
 					CreationTimestamp: "2024-01-01T00:00:00Z",
 				})
 			}
@@ -1143,7 +1164,11 @@ func (api *API) createFirewall(w http.ResponseWriter, r *http.Request, project s
 	api.firewalls[key] = &body
 	api.mu.Unlock()
 
-	api.svcMgr.RegisterFirewallRule(body.Network, orchestrator.FirewallEntry{
+	// Keyed by the short VPC name, not the full network URL — allowedPortsForVPC and
+	// ApplyFirewallPortsToVPC always look this up by short name (derived via
+	// extractNameFromURL), so registering under the full URL would make the lookup
+	// permanently miss.
+	api.svcMgr.RegisterFirewallRule(extractNameFromURL(body.Network), orchestrator.FirewallEntry{
 		Name:      body.Name,
 		VpcName:   extractNameFromURL(body.Network),
 		Direction: body.Direction,
@@ -1156,7 +1181,7 @@ func (api *API) createFirewall(w http.ResponseWriter, r *http.Request, project s
 	op := api.opMgr.Register("compute#operation", "insert", body.SelfLink, "", "")
 	api.opMgr.RunAsync(op.Name, func() error {
 		api.reapplyFirewallToVPC(body.Network)
-		return nil 
+		return nil
 	})
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(op)
@@ -1226,7 +1251,7 @@ func (api *API) patchFirewall(w http.ResponseWriter, r *http.Request, project, n
 	op := api.opMgr.Register("compute#operation", "patch", result.SelfLink, "", "")
 	api.opMgr.RunAsync(op.Name, func() error {
 		api.reapplyFirewallToVPC(result.Network)
-		return nil 
+		return nil
 	})
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(op)
@@ -1247,11 +1272,11 @@ func (api *API) deleteFirewall(w http.ResponseWriter, project, name string) {
 		writeError(w, 404, "NOT_FOUND", "Firewall "+name+" not found")
 		return
 	}
-	api.svcMgr.RemoveFirewallRule(networkURL, name)
+	api.svcMgr.RemoveFirewallRule(extractNameFromURL(networkURL), name)
 	op := api.opMgr.Register("compute#operation", "delete", "", "", "")
 	api.opMgr.RunAsync(op.Name, func() error {
 		api.reapplyFirewallToVPC(networkURL)
-		return nil 
+		return nil
 	})
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(op)
@@ -1267,6 +1292,63 @@ func extractNameFromURL(urlStr string) string {
 		return parts[len(parts)-1]
 	}
 	return ""
+}
+
+// networkInterfaceVPCName returns the short VPC name a network interface
+// references, normalizing an empty Network field to "default" the same way
+// ProvisionComputeVM's caller does.
+func networkInterfaceVPCName(iface NetworkInterface) string {
+	name := extractNameFromURL(iface.Network)
+	if name == "" {
+		name = "default"
+	}
+	return name
+}
+
+// duplicateNetworkInterfaceVPC returns the VPC name shared by two or more
+// network interfaces, or "" if every interface is on a distinct network. Real
+// GCE requires each interface to be on a different VPC network — attaching
+// two NICs to the same network is rejected by instances.insert rather than
+// silently honoring only one of them.
+func duplicateNetworkInterfaceVPC(ifaces []NetworkInterface) string {
+	seen := make(map[string]bool, len(ifaces))
+	for _, iface := range ifaces {
+		vpc := networkInterfaceVPCName(iface)
+		if seen[vpc] {
+			return vpc
+		}
+		seen[vpc] = true
+	}
+	return ""
+}
+
+// dockerNetworkNameForVPC delegates to orchestrator.DockerNetworkNameForVPC,
+// the single source of truth for the VPC-name <-> Docker-network-name
+// mapping shared with ProvisionComputeVM/ConnectContainerToNetwork/
+// attachedVPCNames.
+func dockerNetworkNameForVPC(vpcName string) string {
+	return orchestrator.DockerNetworkNameForVPC(vpcName)
+}
+
+// patchNetworkIPs fills in each network interface's live container IP on its
+// own Docker network, so a multi-NIC VM reports the correct address per
+// interface instead of collapsing them all onto one. It fetches the
+// container's network info once and reuses it across every interface, rather
+// than issuing one Docker inspect call per NIC.
+func (api *API) patchNetworkIPs(inst *Instance, cName string) {
+	ips, err := api.svcMgr.GetContainerNetworks(cName)
+	for j := range inst.NetworkInterfaces {
+		vpcName := extractNameFromURL(inst.NetworkInterfaces[j].Network)
+		dockerNetworkName := dockerNetworkNameForVPC(vpcName)
+		ip := ""
+		if err == nil {
+			ip = ips[dockerNetworkName]
+		}
+		if ip == "" {
+			ip = "10.128.0.2" // Fallback to avoid empty IP which can crash some providers
+		}
+		inst.NetworkInterfaces[j].NetworkIP = ip
+	}
 }
 
 func (api *API) getAllowedPortsForVPC(vpcName string) []string {
@@ -1290,26 +1372,31 @@ func (api *API) reapplyFirewallToVPC(networkURL string) {
 	vpcName := extractNameFromURL(networkURL)
 	var containerNames []string
 	var osImages []string
-	
+
 	api.mu.RLock()
 	for _, inst := range api.instances {
-		if len(inst.NetworkInterfaces) > 0 {
-			nw := extractNameFromURL(inst.NetworkInterfaces[0].Network)
+		matchesVPC := false
+		for _, iface := range inst.NetworkInterfaces {
+			nw := extractNameFromURL(iface.Network)
 			if nw == vpcName || (nw == "" && vpcName == "default") {
-				cName := fmt.Sprintf("minisky-vm-%s", inst.Name)
-				containerNames = append(containerNames, cName)
-				img := "ubuntu:latest"
-				for _, d := range inst.Disks {
-					if strings.Contains(strings.ToLower(d.Source), "centos") {
-						img = "centos:latest"
-					}
-				}
-				osImages = append(osImages, img)
+				matchesVPC = true
+				break
 			}
+		}
+		if matchesVPC {
+			cName := fmt.Sprintf("minisky-vm-%s", inst.Name)
+			containerNames = append(containerNames, cName)
+			img := "ubuntu:latest"
+			for _, d := range inst.Disks {
+				if strings.Contains(strings.ToLower(d.Source), "centos") {
+					img = "centos:latest"
+				}
+			}
+			osImages = append(osImages, img)
 		}
 	}
 	api.mu.RUnlock()
-	
+
 	if len(containerNames) > 0 {
 		api.svcMgr.ApplyFirewallPortsToVPC(vpcName, containerNames, osImages)
 	}

--- a/pkg/shims/compute/api_test.go
+++ b/pkg/shims/compute/api_test.go
@@ -1,0 +1,321 @@
+package compute
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"minisky/pkg/orchestrator"
+)
+
+// fakeTransport routes requests to a handler so tests can fake the Docker
+// daemon's HTTP API without a real socket.
+type fakeTransport struct {
+	handler func(req *http.Request) (*http.Response, error)
+}
+
+func (f *fakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f.handler(req)
+}
+
+func jsonResp(status int, body string) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func TestExtractNameFromURL(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"https://www.googleapis.com/compute/v1/projects/p/global/networks/shared", "shared"},
+		{"default", "default"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := extractNameFromURL(tt.in); got != tt.want {
+			t.Errorf("extractNameFromURL(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestDockerNetworkNameForVPC(t *testing.T) {
+	tests := []struct {
+		vpcName string
+		want    string
+	}{
+		{"", "minisky-net"},
+		{"default", "minisky-net"},
+		{"shared", "minisky-vpc-shared"},
+	}
+	for _, tt := range tests {
+		if got := dockerNetworkNameForVPC(tt.vpcName); got != tt.want {
+			t.Errorf("dockerNetworkNameForVPC(%q) = %q, want %q", tt.vpcName, got, tt.want)
+		}
+	}
+}
+
+func TestGetAllowedPortsForVPC(t *testing.T) {
+	api := NewAPI(nil, nil)
+	api.firewalls["p:allow-default"] = &FirewallRule{
+		Network:   "https://www.googleapis.com/compute/v1/projects/p/global/networks/default",
+		Direction: "INGRESS",
+		Action:    "allow",
+		Allowed:   []FirewallAllow{{Ports: []string{"22"}}},
+	}
+	api.firewalls["p:allow-shared"] = &FirewallRule{
+		Network:   "https://www.googleapis.com/compute/v1/projects/p/global/networks/shared",
+		Direction: "INGRESS",
+		Action:    "allow",
+		Allowed:   []FirewallAllow{{Ports: []string{"80", "443"}}},
+	}
+	api.firewalls["p:deny-shared"] = &FirewallRule{
+		Network:   "https://www.googleapis.com/compute/v1/projects/p/global/networks/shared",
+		Direction: "INGRESS",
+		Action:    "deny",
+		Allowed:   []FirewallAllow{{Ports: []string{"3389"}}},
+	}
+
+	if got := api.getAllowedPortsForVPC("default"); !equalSet(got, []string{"22"}) {
+		t.Errorf("default ports = %v, want [22]", got)
+	}
+	if got := api.getAllowedPortsForVPC("shared"); !equalSet(got, []string{"80", "443"}) {
+		t.Errorf("shared ports = %v, want [80 443]", got)
+	}
+}
+
+func equalSet(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	set := map[string]bool{}
+	for _, g := range got {
+		set[g] = true
+	}
+	for _, w := range want {
+		if !set[w] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestPatchNetworkIPs_PerInterfaceOnItsOwnNetwork(t *testing.T) {
+	ft := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+		return jsonResp(http.StatusOK, `{"NetworkSettings":{"Networks":{
+			"minisky-net": {"IPAddress": "172.18.0.2"},
+			"minisky-vpc-shared": {"IPAddress": "172.19.0.5"}
+		}}}`)
+	}}
+	svcMgr := orchestrator.NewServiceManagerForTesting(ft)
+	api := NewAPI(nil, svcMgr)
+
+	inst := &Instance{
+		NetworkInterfaces: []NetworkInterface{
+			{Network: "https://www.googleapis.com/compute/v1/projects/p/global/networks/default"},
+			{Network: "https://www.googleapis.com/compute/v1/projects/p/global/networks/shared"},
+		},
+	}
+
+	api.patchNetworkIPs(inst, "my-vm")
+
+	if inst.NetworkInterfaces[0].NetworkIP != "172.18.0.2" {
+		t.Errorf("nic0 IP = %q, want 172.18.0.2", inst.NetworkInterfaces[0].NetworkIP)
+	}
+	if inst.NetworkInterfaces[1].NetworkIP != "172.19.0.5" {
+		t.Errorf("nic1 IP = %q, want 172.19.0.5", inst.NetworkInterfaces[1].NetworkIP)
+	}
+}
+
+func TestReapplyFirewallToVPC_MatchesSecondaryNIC(t *testing.T) {
+	var calls []string
+	ft := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+		calls = append(calls, req.Method+" "+req.URL.Path)
+		switch {
+		case req.Method == "GET" && strings.HasSuffix(req.URL.Path, "/json"):
+			return jsonResp(http.StatusOK, `{"NetworkSettings":{"Networks":{"minisky-net":{}},"Ports":{}}}`)
+		default:
+			return jsonResp(http.StatusOK, "{}")
+		}
+	}}
+	svcMgr := orchestrator.NewServiceManagerForTesting(ft)
+	api := NewAPI(nil, svcMgr)
+
+	// nic0 is "default", nic1 is "prod" — a firewall change on "prod" must
+	// still pick this instance up even though it's not the primary NIC.
+	api.instances["p:z:vm1"] = &Instance{
+		Name: "vm1",
+		NetworkInterfaces: []NetworkInterface{
+			{Network: "https://www.googleapis.com/compute/v1/projects/p/global/networks/default"},
+			{Network: "https://www.googleapis.com/compute/v1/projects/p/global/networks/prod"},
+		},
+	}
+
+	api.reapplyFirewallToVPC("https://www.googleapis.com/compute/v1/projects/p/global/networks/prod")
+
+	var sawDelete bool
+	for _, c := range calls {
+		if strings.HasPrefix(c, "DELETE") {
+			sawDelete = true
+		}
+	}
+	if !sawDelete {
+		t.Errorf("expected reapplyFirewallToVPC to recreate the instance whose secondary NIC is on the changed VPC, calls were: %v", calls)
+	}
+}
+
+func TestPatchNetworkIPs_FallsBackWhenNetworkMissing(t *testing.T) {
+	ft := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+		return jsonResp(http.StatusOK, `{"NetworkSettings":{"Networks":{}}}`)
+	}}
+	svcMgr := orchestrator.NewServiceManagerForTesting(ft)
+	api := NewAPI(nil, svcMgr)
+
+	inst := &Instance{
+		NetworkInterfaces: []NetworkInterface{
+			{Network: "https://www.googleapis.com/compute/v1/projects/p/global/networks/default"},
+		},
+	}
+
+	api.patchNetworkIPs(inst, "my-vm")
+
+	if inst.NetworkInterfaces[0].NetworkIP != "10.128.0.2" {
+		t.Errorf("nic0 IP = %q, want fallback 10.128.0.2", inst.NetworkInterfaces[0].NetworkIP)
+	}
+}
+
+func TestGetInstance_SubnetworkBackfilledForEveryInterface(t *testing.T) {
+	ft := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+		return jsonResp(http.StatusOK, `{"NetworkSettings":{"Networks":{
+			"minisky-net": {"IPAddress": "172.18.0.2"},
+			"minisky-vpc-shared": {"IPAddress": "172.19.0.5"}
+		}}}`)
+	}}
+	svcMgr := orchestrator.NewServiceManagerForTesting(ft)
+	api := NewAPI(nil, svcMgr)
+
+	// nic1 (on "shared") has no explicit Subnetwork, same as a client that never set
+	// one — getInstance should backfill it just like it already does for nic0.
+	api.instances[instanceKey("p", "us-central1-a", "vm1")] = &Instance{
+		Name: "vm1",
+		NetworkInterfaces: []NetworkInterface{
+			{Network: "https://www.googleapis.com/compute/v1/projects/p/global/networks/default"},
+			{Network: "https://www.googleapis.com/compute/v1/projects/p/global/networks/shared"},
+		},
+	}
+
+	w := httptest.NewRecorder()
+	api.getInstance(w, httptest.NewRequest(http.MethodGet, "/", nil), "p", "us-central1-a", "vm1")
+
+	var got Instance
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	for j, iface := range got.NetworkInterfaces {
+		if iface.Subnetwork == "" {
+			t.Errorf("nic%d Subnetwork is empty, want it backfilled like nic0 already was", j)
+		}
+	}
+}
+
+func TestDuplicateNetworkInterfaceVPC(t *testing.T) {
+	tests := []struct {
+		name   string
+		ifaces []NetworkInterface
+		want   string
+	}{
+		{
+			name: "distinct networks, no duplicate",
+			ifaces: []NetworkInterface{
+				{Network: "https://www.googleapis.com/compute/v1/projects/p/global/networks/default"},
+				{Network: "https://www.googleapis.com/compute/v1/projects/p/global/networks/shared"},
+			},
+			want: "",
+		},
+		{
+			name: "same network on two NICs is a duplicate",
+			ifaces: []NetworkInterface{
+				{Network: "https://www.googleapis.com/compute/v1/projects/p/global/networks/shared"},
+				{Network: "https://www.googleapis.com/compute/v1/projects/p/global/networks/shared"},
+			},
+			want: "shared",
+		},
+		{
+			name: "empty network field normalizes to default and collides with an explicit default",
+			ifaces: []NetworkInterface{
+				{Network: "https://www.googleapis.com/compute/v1/projects/p/global/networks/default"},
+				{Network: ""},
+			},
+			want: "default",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := duplicateNetworkInterfaceVPC(tt.ifaces); got != tt.want {
+				t.Errorf("duplicateNetworkInterfaceVPC() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInsertInstance_RejectsDuplicateNetworkInterfaceVPC(t *testing.T) {
+	// Real GCE rejects instances.insert outright when two network interfaces
+	// reference the same VPC network — it never silently attaches only one.
+	api := NewAPI(orchestrator.NewOperationManager(), orchestrator.NewServiceManagerForTesting(&fakeTransport{
+		handler: func(req *http.Request) (*http.Response, error) {
+			return jsonResp(http.StatusOK, "{}")
+		},
+	}))
+
+	body := `{
+		"name": "vm1",
+		"networkInterfaces": [
+			{"network": "https://www.googleapis.com/compute/v1/projects/p/global/networks/default"},
+			{"network": "https://www.googleapis.com/compute/v1/projects/p/global/networks/default"}
+		]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/compute/v1/projects/p/zones/us-central1-a/instances", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	api.insertInstance(w, req, "p", "us-central1-a")
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("got status %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	if _, ok := api.instances[instanceKey("p", "us-central1-a", "vm1")]; ok {
+		t.Error("instance should not have been created when networkInterfaces are invalid")
+	}
+}
+
+func TestCreateFirewall_RegistersRuleUnderShortVPCName(t *testing.T) {
+	// createFirewall stores the rule keyed by the full network URL in
+	// api.firewalls (fine, getAllowedPortsForVPC extracts the short name at read
+	// time there), but it must register with the orchestrator under the short VPC
+	// name — allowedPortsForVPC/ApplyFirewallPortsToVPC always look it up by short
+	// name, so registering under the full URL would make that lookup permanently
+	// miss and silently close every port on a firewall-triggered VM recreate.
+	svcMgr := orchestrator.NewServiceManagerForTesting(&fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+		return jsonResp(http.StatusOK, "{}")
+	}})
+	api := NewAPI(orchestrator.NewOperationManager(), svcMgr)
+
+	body := `{
+		"name": "allow-web",
+		"network": "https://www.googleapis.com/compute/v1/projects/p/global/networks/shared",
+		"direction": "INGRESS",
+		"action": "allow",
+		"allowed": [{"IPProtocol": "tcp", "ports": ["8080"]}]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/compute/v1/projects/p/global/firewalls", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	api.createFirewall(w, req, "p")
+
+	if !svcMgr.CheckFirewallAllows("shared", "tcp", "8080", "1.2.3.4") {
+		t.Error("firewall rule registered by createFirewall is not visible under the short VPC name 'shared'")
+	}
+}

--- a/pkg/shims/dataproc/api.go
+++ b/pkg/shims/dataproc/api.go
@@ -26,13 +26,13 @@ func init() {
 
 // Cluster mirrors the Dataproc v1 Cluster resource.
 type Cluster struct {
-	ProjectId   string        `json:"projectId"`
-	ClusterName string        `json:"clusterName"`
-	ClusterUuid string        `json:"clusterUuid"`
-	Config      ClusterConfig `json:"config"`
-	Status      ClusterStatus `json:"status"`
-	StatusHistory []ClusterStatus `json:"statusHistory,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty"`
+	ProjectId     string            `json:"projectId"`
+	ClusterName   string            `json:"clusterName"`
+	ClusterUuid   string            `json:"clusterUuid"`
+	Config        ClusterConfig     `json:"config"`
+	Status        ClusterStatus     `json:"status"`
+	StatusHistory []ClusterStatus   `json:"statusHistory,omitempty"`
+	Labels        map[string]string `json:"labels,omitempty"`
 }
 
 type ClusterConfig struct {
@@ -42,8 +42,8 @@ type ClusterConfig struct {
 }
 
 type InstanceGroupConfig struct {
-	NumInstances   int    `json:"numInstances"`
-	MachineTypeUri string `json:"machineTypeUri"`
+	NumInstances   int         `json:"numInstances"`
+	MachineTypeUri string      `json:"machineTypeUri"`
 	DiskConfig     *DiskConfig `json:"diskConfig,omitempty"`
 }
 
@@ -64,12 +64,12 @@ type ClusterStatus struct {
 
 // Job mirrors the Dataproc v1 Job resource.
 type Job struct {
-	Reference  JobReference `json:"reference"`
-	Placement  JobPlacement `json:"placement"`
-	Status     JobStatus    `json:"status"`
-	SparkJob   *SparkJob    `json:"sparkJob,omitempty"`
-	PysparkJob *PySparkJob  `json:"pysparkJob,omitempty"`
-	HiveJob    *HiveJob     `json:"hiveJob,omitempty"`
+	Reference  JobReference      `json:"reference"`
+	Placement  JobPlacement      `json:"placement"`
+	Status     JobStatus         `json:"status"`
+	SparkJob   *SparkJob         `json:"sparkJob,omitempty"`
+	PysparkJob *PySparkJob       `json:"pysparkJob,omitempty"`
+	HiveJob    *HiveJob          `json:"hiveJob,omitempty"`
 	Labels     map[string]string `json:"labels,omitempty"`
 }
 
@@ -90,10 +90,10 @@ type JobStatus struct {
 }
 
 type SparkJob struct {
-	MainClass  string   `json:"mainClass,omitempty"`
-	MainJarFileUri string `json:"mainJarFileUri,omitempty"`
-	Args       []string `json:"args,omitempty"`
-	JarFileUris []string `json:"jarFileUris,omitempty"`
+	MainClass      string   `json:"mainClass,omitempty"`
+	MainJarFileUri string   `json:"mainJarFileUri,omitempty"`
+	Args           []string `json:"args,omitempty"`
+	JarFileUris    []string `json:"jarFileUris,omitempty"`
 }
 
 type PySparkJob struct {
@@ -103,8 +103,8 @@ type PySparkJob struct {
 }
 
 type HiveJob struct {
-	QueryList *QueryList `json:"queryList,omitempty"`
-	QueryFileUri string  `json:"queryFileUri,omitempty"`
+	QueryList    *QueryList `json:"queryList,omitempty"`
+	QueryFileUri string     `json:"queryFileUri,omitempty"`
 }
 
 type QueryList struct {
@@ -136,14 +136,15 @@ func NewAPI(opMgr *orchestrator.OperationManager, svcMgr *orchestrator.ServiceMa
 // ServeHTTP dispatches Dataproc v1 paths.
 //
 // Supported paths (dataproc.googleapis.com):
-//   POST   /v1/projects/{project}/regions/{region}/clusters
-//   GET    /v1/projects/{project}/regions/{region}/clusters
-//   GET    /v1/projects/{project}/regions/{region}/clusters/{cluster}
-//   DELETE /v1/projects/{project}/regions/{region}/clusters/{cluster}
-//   POST   /v1/projects/{project}/regions/{region}/jobs:submit
-//   GET    /v1/projects/{project}/regions/{region}/jobs
-//   GET    /v1/projects/{project}/regions/{region}/jobs/{jobId}
-//   GET    /v1/projects/{project}/regions/{region}/operations/{operation}
+//
+//	POST   /v1/projects/{project}/regions/{region}/clusters
+//	GET    /v1/projects/{project}/regions/{region}/clusters
+//	GET    /v1/projects/{project}/regions/{region}/clusters/{cluster}
+//	DELETE /v1/projects/{project}/regions/{region}/clusters/{cluster}
+//	POST   /v1/projects/{project}/regions/{region}/jobs:submit
+//	GET    /v1/projects/{project}/regions/{region}/jobs
+//	GET    /v1/projects/{project}/regions/{region}/jobs/{jobId}
+//	GET    /v1/projects/{project}/regions/{region}/operations/{operation}
 func (api *API) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	log.Printf("[Shim: Dataproc] %s %s", r.Method, r.URL.Path)
 	w.Header().Set("Content-Type", "application/json")
@@ -190,8 +191,8 @@ func (api *API) routeClusters(w http.ResponseWriter, r *http.Request, path strin
 
 func (api *API) createCluster(w http.ResponseWriter, r *http.Request, project, region string) {
 	var body struct {
-		ClusterName string        `json:"clusterName"`
-		Config      ClusterConfig `json:"config"`
+		ClusterName string            `json:"clusterName"`
+		Config      ClusterConfig     `json:"config"`
 		Labels      map[string]string `json:"labels"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -271,7 +272,7 @@ func (api *API) createCluster(w http.ResponseWriter, r *http.Request, project, r
 		}
 
 		masterName := fmt.Sprintf("minisky-dataproc-%s-m", clusterStr)
-		api.svcMgr.ProvisionComputeVM(masterName, masterImage, "default", reg.Dataproc.MasterPorts, connectivityEnv, []string{"tail", "-f", "/dev/null"})
+		api.svcMgr.ProvisionComputeVM(masterName, masterImage, []string{"default"}, reg.Dataproc.MasterPorts, connectivityEnv, []string{"tail", "-f", "/dev/null"})
 
 		// Provision Worker Nodes
 		numWorkers := 2
@@ -280,7 +281,7 @@ func (api *API) createCluster(w http.ResponseWriter, r *http.Request, project, r
 		}
 		for i := 0; i < numWorkers; i++ {
 			workerName := fmt.Sprintf("minisky-dataproc-%s-w-%d", clusterStr, i)
-			api.svcMgr.ProvisionComputeVM(workerName, masterImage, "default", []string{}, connectivityEnv, []string{"tail", "-f", "/dev/null"})
+			api.svcMgr.ProvisionComputeVM(workerName, masterImage, []string{"default"}, []string{}, connectivityEnv, []string{"tail", "-f", "/dev/null"})
 		}
 
 		api.mu.Lock()
@@ -332,7 +333,7 @@ func (api *API) deleteCluster(w http.ResponseWriter, r *http.Request, project, r
 	cl, ok := api.clusters[key]
 	if ok {
 		cl.Status.State = "DELETING"
-		// Delay actual map deletion to allow UI to see DELETING state briefly, 
+		// Delay actual map deletion to allow UI to see DELETING state briefly,
 		// but since we want to align with previous exact behavior, we just copy properties.
 	}
 	api.mu.Unlock()
@@ -352,8 +353,8 @@ func (api *API) deleteCluster(w http.ResponseWriter, r *http.Request, project, r
 		"https://dataproc.googleapis.com/v1/projects/%s/regions/%s/clusters/%s",
 		project, region, name)
 	op := api.opMgr.Register("dataproc#operation", "DELETE", targetLink, "", region)
-	
-	api.opMgr.RunAsync(op.Name, func() error { 
+
+	api.opMgr.RunAsync(op.Name, func() error {
 		// Teardown physical containers
 		api.svcMgr.DeleteComputeVM(fmt.Sprintf("minisky-dataproc-%s-m", name))
 		for i := 0; i < numWorkers; i++ {
@@ -363,7 +364,7 @@ func (api *API) deleteCluster(w http.ResponseWriter, r *http.Request, project, r
 		api.mu.Lock()
 		delete(api.clusters, key)
 		api.mu.Unlock()
-		return nil 
+		return nil
 	})
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(toLRO(op, project, region))
@@ -436,7 +437,7 @@ func (api *API) submitJob(w http.ResponseWriter, r *http.Request, project, regio
 		api.mu.Unlock()
 
 		masterName := fmt.Sprintf("minisky-dataproc-%s-m", clusterName)
-		
+
 		var cmd []string
 		if j.PysparkJob != nil {
 			cmd = []string{"spark-submit", "--master", "spark://localhost:7077", j.PysparkJob.MainPythonFileUri}

--- a/pkg/shims/memorystore/api.go
+++ b/pkg/shims/memorystore/api.go
@@ -29,34 +29,34 @@ func init() {
 }
 
 type Instance struct {
-	Name         string            `json:"name"`
-	DisplayName  string            `json:"displayName,omitempty"`
-	Labels       map[string]string `json:"labels,omitempty"`
-	Tier         string            `json:"tier"` // BASIC, STANDARD_HA
-	MemorySizeGb int               `json:"memorySizeGb"`
-	Host         string            `json:"host"`
-	Port         int               `json:"port"`
-	State        string            `json:"state"` // CREATING, READY, DELETING, REPAIRING, MAINTENANCE
-	CreateTime   string            `json:"createTime"`
-	LocationId   string            `json:"locationId"`
-	AlternativeLocationId string    `json:"alternativeLocationId,omitempty"`
-	AuthorizedNetwork     string    `json:"authorizedNetwork,omitempty"`
+	Name                  string             `json:"name"`
+	DisplayName           string             `json:"displayName,omitempty"`
+	Labels                map[string]string  `json:"labels,omitempty"`
+	Tier                  string             `json:"tier"` // BASIC, STANDARD_HA
+	MemorySizeGb          int                `json:"memorySizeGb"`
+	Host                  string             `json:"host"`
+	Port                  int                `json:"port"`
+	State                 string             `json:"state"` // CREATING, READY, DELETING, REPAIRING, MAINTENANCE
+	CreateTime            string             `json:"createTime"`
+	LocationId            string             `json:"locationId"`
+	AlternativeLocationId string             `json:"alternativeLocationId,omitempty"`
+	AuthorizedNetwork     string             `json:"authorizedNetwork,omitempty"`
 	PersistenceConfig     *PersistenceConfig `json:"persistenceConfig,omitempty"`
-	EngineVersion         string    `json:"engineVersion,omitempty"` // REDIS_6_X, MEMCACHED_1_5, etc.
+	EngineVersion         string             `json:"engineVersion,omitempty"` // REDIS_6_X, MEMCACHED_1_5, etc.
 }
 
 type PersistenceConfig struct {
-	PersistenceMode    string `json:"persistenceMode"` // DISABLED, RDB
-	RdbSnapshotPeriod  string `json:"rdbSnapshotPeriod,omitempty"`
+	PersistenceMode   string `json:"persistenceMode"` // DISABLED, RDB
+	RdbSnapshotPeriod string `json:"rdbSnapshotPeriod,omitempty"`
 }
 
 type API struct {
-	mu       sync.RWMutex
-	opMgr    *orchestrator.OperationManager
-	svcMgr   *orchestrator.ServiceManager
-	logAPI   *logging.API
+	mu     sync.RWMutex
+	opMgr  *orchestrator.OperationManager
+	svcMgr *orchestrator.ServiceManager
+	logAPI *logging.API
 	// map[projectId]map[instanceId]*Instance
-	redisInstances map[string]map[string]*Instance
+	redisInstances    map[string]map[string]*Instance
 	memcacheInstances map[string]map[string]*Instance
 }
 
@@ -83,9 +83,9 @@ func (api *API) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Routing for Redis and Memcached
 	// Paths typically look like: /v1/projects/{project}/locations/{location}/instances
-	
+
 	isRedis := strings.Contains(r.Host, "redis")
-	
+
 	if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/instances") {
 		api.handleListInstances(w, r, isRedis)
 		return
@@ -135,7 +135,7 @@ func (api *API) handleListInstances(w http.ResponseWriter, r *http.Request, isRe
 func (api *API) handleGetInstance(w http.ResponseWriter, r *http.Request, isRedis bool) {
 	project := extractProject(r.URL.Path)
 	instanceId := r.URL.Path[strings.LastIndex(r.URL.Path, "/")+1:]
-	
+
 	api.mu.RLock()
 	defer api.mu.RUnlock()
 
@@ -160,7 +160,7 @@ func (api *API) handleGetInstance(w http.ResponseWriter, r *http.Request, isRedi
 
 func (api *API) handleCreateInstance(w http.ResponseWriter, r *http.Request, isRedis bool) {
 	var req struct {
-		InstanceId string `json:"instanceId"`
+		InstanceId string   `json:"instanceId"`
 		Instance   Instance `json:"instance"`
 	}
 	// Google Cloud API sometimes passes instanceId as a query param
@@ -217,7 +217,9 @@ func (api *API) handleCreateInstance(w http.ResponseWriter, r *http.Request, isR
 			vparts := strings.Split(v, "_")
 			if len(vparts) > 1 {
 				targetV := vparts[1]
-				if len(vparts) > 2 { targetV += "." + vparts[2] }
+				if len(vparts) > 2 {
+					targetV += "." + vparts[2]
+				}
 				for _, mv := range reg.Memorystore.Redis.Versions {
 					if strings.HasPrefix(mv.Version, targetV) {
 						image = mv.Image
@@ -232,10 +234,10 @@ func (api *API) handleCreateInstance(w http.ResponseWriter, r *http.Request, isR
 			image = reg.Memorystore.Memcached.DefaultImage
 			containerPrefix = "memcache"
 		}
-		
+
 		containerName := fmt.Sprintf("minisky-%s-%s", containerPrefix, id)
-		err := api.svcMgr.ProvisionComputeVM(containerName, image, "default", []string{fmt.Sprintf("%d", req.Instance.Port)}, []string{}, nil)
-		
+		err := api.svcMgr.ProvisionComputeVM(containerName, image, []string{"default"}, []string{fmt.Sprintf("%d", req.Instance.Port)}, []string{}, nil)
+
 		api.mu.Lock()
 		if err != nil {
 			req.Instance.State = "REPAIRING"
@@ -243,7 +245,7 @@ func (api *API) handleCreateInstance(w http.ResponseWriter, r *http.Request, isR
 		} else {
 			req.Instance.State = "READY"
 			api.pushLog(project, "INFO", id, fmt.Sprintf("Instance %s is now READY", id))
-			
+
 			// Retrieve the dynamic host port assigned by Docker
 			containerPort := "6379/tcp"
 			if !isRedis {
@@ -302,7 +304,7 @@ func (api *API) handleDeleteInstance(w http.ResponseWriter, r *http.Request, isR
 		}
 		containerName := fmt.Sprintf("minisky-%s-%s", containerPrefix, id)
 		api.svcMgr.DeleteComputeVM(containerName)
-		
+
 		api.mu.Lock()
 		sourceMap := api.redisInstances
 		if !isRedis {


### PR DESCRIPTION
## Summary
- Compute VMs with multiple `networkInterfaces` now get a Docker network per
  interface instead of every interface silently collapsing onto nic0's network.
- Firewall rules now follow every VPC a VM is attached to (not just its
  primary NIC) on both direct reapplication and VM recreation.
- Instances whose interfaces reference the same VPC twice are rejected at
  insert time, matching real GCE `instances.insert` validation, instead of
  silently attaching only one of them.
- Network attach/container-start failures roll the container back entirely,
  matching GCE's atomic "every requested NIC or none" semantics.

## Why
Before this change, `ServiceManager.ProvisionComputeVM` only accepted a single
VPC name, so a VM created with N network interfaces was always attached to
just one Docker network. That silently diverged from what GCE (and therefore
Terraform's `google_compute_instance`) actually supports, made `networkIP`
identical across every reported interface, and caused firewall rules applied
to a non-primary VPC to never reach the VMs attached to it.

## Changes
- `ProvisionComputeVM` takes `vpcNames []string`; extra networks are attached
  post-create via `ConnectContainerToNetwork`, rolled back atomically on
  failure (including container-start failure).
- `DockerNetworkNameForVPC` / `VPCNameForDockerNetwork` are the single source
  of truth for the VPC-name ↔ Docker-network-name mapping; `CreateVPCNetwork`/
  `DeleteVPCNetwork` now reuse it instead of re-deriving the prefix.
- `ApplyFirewallPortsToVPC` recreates a VM with every VPC it's attached to
  (tracked via a new `vpcRegistry`, falling back to a live Docker inspect) and
  merges allowed ports across all of them.
- `insertInstance` builds one VPC name per `networkInterface` and rejects
  duplicate-VPC interfaces with `INVALID_ARGUMENT`.
- `getInstance`/`listInstances` report each interface's real per-network IP
  and backfill its subnetwork individually; `listInstances`' Docker lookups
  now run concurrently.
- `reapplyFirewallToVPC` matches instances by *any* attached NIC, not just nic0.
- Fixed firewall rules being registered under the full network URL instead of
  the short VPC name — this silently broke port reapplication on every VM
  recreate.
- Tightened error handling on container remove/inspect Docker calls that
  previously swallowed non-2xx responses.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — new coverage in `pkg/orchestrator/manager_test.go` and
      `pkg/shims/compute/api_test.go` for: multi-network attach/rollback
      (including start-failure rollback), VPC dedup, firewall-port merging
      across attached VPCs, per-interface IP/subnetwork patching, duplicate-NIC
      rejection, and the `CreateVPCNetwork`/`DeleteVPCNetwork` naming fix.
- [x] Create a VM that has two `network_interface`s confirm both get distinct IPs and
      are attached to the separate NICs. (see below)

```hcl
terraform {
  required_providers {
    google = {
      source = "hashicorp/google"
      version = "6.8.0"
    }
  }
}

variable "gcp_environment" {
  description = "Set to 'local' to use MiniSky"
  default     = "local"
}

provider "google" {
  project      = "local-dev-project"
  region       = "us-central1"
  zone         = "us-central1-a"
  
  # Authentication (Emulated)
  # MiniSky's internal proxy accepts any well-formed token but will not validate it against Google's servers.
  # Using access_token is recommended over mock JSON credentials to avoid local ASN.1 parsing errors.
  access_token = "minisky-local-token"

  # Custom Endpoints for Local Development
  storage_custom_endpoint         = var.gcp_environment == "local" ? "http://localhost:8080/storage/v1/" : null
  cloud_functions_custom_endpoint = var.gcp_environment == "local" ? "http://localhost:8080/v2/" : null
  pubsub_custom_endpoint          = var.gcp_environment == "local" ? "http://localhost:8080/" : null
  compute_custom_endpoint         = var.gcp_environment == "local" ? "http://localhost:8080/compute/v1/" : null
  big_query_custom_endpoint       = var.gcp_environment == "local" ? "http://localhost:8080/bigquery/v2/" : null
  cloud_run_custom_endpoint       = var.gcp_environment == "local" ? "http://localhost:8080/v2/" : null
  firestore_custom_endpoint       = var.gcp_environment == "local" ? "http://localhost:8080/" : null
}

resource "google_compute_network" "vpc_network" {
  name = "terraform-network"
}

resource "google_compute_network" "vpc_network_2" {
  name = "terraform-network-2"
}

resource "google_compute_instance" "vm_instance" {
  name         = "terraform-instance"
  machine_type = "f1-micro"

  boot_disk {
    initialize_params {
      image = "debian-cloud/debian-11"
    }
  }

  network_interface {
    network = google_compute_network.vpc_network.name
    access_config {
    }
  }
  network_interface {
    network = google_compute_network.vpc_network_2.name
    access_config {
    }
  }
}
```

`terraform apply`
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # google_compute_instance.vm_instance will be created
  + resource "google_compute_instance" "vm_instance" {
      + can_ip_forward       = false
      + cpu_platform         = (known after apply)
      + current_status       = (known after apply)
      + deletion_protection  = false
      + effective_labels     = {
          + "goog-terraform-provisioned" = "true"
        }
      + id                   = (known after apply)
      + instance_id          = (known after apply)
      + label_fingerprint    = (known after apply)
      + machine_type         = "f1-micro"
      + metadata_fingerprint = (known after apply)
      + min_cpu_platform     = (known after apply)
      + name                 = "terraform-instance"
      + project              = "local-dev-project"
      + self_link            = (known after apply)
      + tags_fingerprint     = (known after apply)
      + terraform_labels     = {
          + "goog-terraform-provisioned" = "true"
        }
      + zone                 = "us-central1-a"

      + boot_disk {
          + auto_delete                = true
          + device_name                = (known after apply)
          + disk_encryption_key_sha256 = (known after apply)
          + kms_key_self_link          = (known after apply)
          + mode                       = "READ_WRITE"
          + source                     = (known after apply)

          + initialize_params {
              + image                  = "debian-cloud/debian-11"
              + labels                 = (known after apply)
              + provisioned_iops       = (known after apply)
              + provisioned_throughput = (known after apply)
              + resource_policies      = (known after apply)
              + size                   = (known after apply)
              + type                   = (known after apply)
            }
        }

      + confidential_instance_config (known after apply)

      + guest_accelerator (known after apply)

      + network_interface {
          + internal_ipv6_prefix_length = (known after apply)
          + ipv6_access_type            = (known after apply)
          + ipv6_address                = (known after apply)
          + name                        = (known after apply)
          + network                     = "terraform-network"
          + network_ip                  = (known after apply)
          + stack_type                  = (known after apply)
          + subnetwork                  = (known after apply)
          + subnetwork_project          = (known after apply)

          + access_config {
              + nat_ip       = (known after apply)
              + network_tier = (known after apply)
            }
        }
      + network_interface {
          + internal_ipv6_prefix_length = (known after apply)
          + ipv6_access_type            = (known after apply)
          + ipv6_address                = (known after apply)
          + name                        = (known after apply)
          + network                     = "terraform-network-2"
          + network_ip                  = (known after apply)
          + stack_type                  = (known after apply)
          + subnetwork                  = (known after apply)
          + subnetwork_project          = (known after apply)

          + access_config {
              + nat_ip       = (known after apply)
              + network_tier = (known after apply)
            }
        }

      + reservation_affinity (known after apply)

      + scheduling (known after apply)
    }

  # google_compute_network.vpc_network will be created
  + resource "google_compute_network" "vpc_network" {
      + auto_create_subnetworks                   = true
      + delete_default_routes_on_create           = false
      + gateway_ipv4                              = (known after apply)
      + id                                        = (known after apply)
      + internal_ipv6_range                       = (known after apply)
      + mtu                                       = (known after apply)
      + name                                      = "terraform-network"
      + network_firewall_policy_enforcement_order = "AFTER_CLASSIC_FIREWALL"
      + numeric_id                                = (known after apply)
      + project                                   = "local-dev-project"
      + routing_mode                              = (known after apply)
      + self_link                                 = (known after apply)
    }

  # google_compute_network.vpc_network_2 will be created
  + resource "google_compute_network" "vpc_network_2" {
      + auto_create_subnetworks                   = true
      + delete_default_routes_on_create           = false
      + gateway_ipv4                              = (known after apply)
      + id                                        = (known after apply)
      + internal_ipv6_range                       = (known after apply)
      + mtu                                       = (known after apply)
      + name                                      = "terraform-network-2"
      + network_firewall_policy_enforcement_order = "AFTER_CLASSIC_FIREWALL"
      + numeric_id                                = (known after apply)
      + project                                   = "local-dev-project"
      + routing_mode                              = (known after apply)
      + self_link                                 = (known after apply)
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

google_compute_network.vpc_network: Creating...
google_compute_network.vpc_network_2: Creating...
google_compute_network.vpc_network: Still creating... [00m10s elapsed]
google_compute_network.vpc_network_2: Still creating... [00m10s elapsed]
google_compute_network.vpc_network_2: Creation complete after 10s [id=projects/local-dev-project/global/networks/terraform-network-2]
google_compute_network.vpc_network: Creation complete after 10s [id=projects/local-dev-project/global/networks/terraform-network]
google_compute_instance.vm_instance: Creating...
google_compute_instance.vm_instance: Still creating... [00m10s elapsed]
google_compute_instance.vm_instance: Creation complete after 10s [id=projects/local-dev-project/zones/us-central1-a/instances/terraform-instance]
```

`docker inspect minisky-vm-terraform-instance | jq '.[].NetworkSettings.Networks'`:

```json
{
  "minisky-vpc-terraform-network": {
    "IPAMConfig": null,
    "Links": null,
    "Aliases": null,
    "MacAddress": "96:70:36:83:a1:37",
    "DriverOpts": null,
    "GwPriority": 0,
    "NetworkID": "de5de871204a3c7035e5b6c337229cf369e4d8747c17dbb3871b4f96f24536ed",
    "EndpointID": "5c009f1482ae08cd4a867ef6eba1fb8810bd7c91969ef946ade8e90293177de8",
    "Gateway": "172.23.0.1",
    "IPAddress": "172.23.0.2",
    "IPPrefixLen": 16,
    "IPv6Gateway": "",
    "GlobalIPv6Address": "",
    "GlobalIPv6PrefixLen": 0,
    "DNSNames": [
      "minisky-vm-terraform-instance",
      "f91d3e7c03ad"
    ]
  },
  "minisky-vpc-terraform-network-2": {
    "IPAMConfig": null,
    "Links": null,
    "Aliases": null,
    "MacAddress": "4e:cf:90:40:75:28",
    "DriverOpts": null,
    "GwPriority": 0,
    "NetworkID": "4fc4305b2fcea7305288445268c0617b4481c489349f5952fe7f03701aa282f6",
    "EndpointID": "b2d2a577989e5af2efe5cc976b2dadb8903e53a742640374b094a9bff1496fbb",
    "Gateway": "172.24.0.1",
    "IPAddress": "172.24.0.2",
    "IPPrefixLen": 16,
    "IPv6Gateway": "",
    "GlobalIPv6Address": "",
    "GlobalIPv6PrefixLen": 0,
    "DNSNames": [
      "minisky-vm-terraform-instance",
      "f91d3e7c03ad"
    ]
  }
}

```
Closes #3 